### PR TITLE
Fix NoneType crash when inviting outsider mates in lead-den events

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -457,8 +457,8 @@ def handle_lead_den_event():
         # ADJUST REP
         game.clan.reputation += chosen_event["rep_change"]
 
-        additional_mates = None
-        additional_kits = None
+        additional_mates = []
+        additional_kits = []
         # SUCCESS/FAIL
         if info_dict["success"]:
             if info_dict["interaction_type"] == "hunt":
@@ -487,8 +487,8 @@ def handle_lead_den_event():
                         and not mate.dead
                         and not CatStanding.EXILED
                     ):
-                        additional_mates.append(mate)
-                    additional_mates = outsider_cat.add_to_clan()
+                        mate.add_to_clan()
+                        additional_mates.append(mate.ID)
                 
                 if additional_kits:
                     event_text += i18n.t(
@@ -501,15 +501,11 @@ def handle_lead_den_event():
 
                 if additional_mates:
                     event_text += i18n.t("hardcoded.event_lost_mate")
-                    
-                    for mate_id in lost_cat.mate:
-                            # add to involved cat list
-                        involved_cats.append(mate_id)
+                    involved_cats.extend(additional_mates)
                 
                 invited_cats = [outsider_cat.ID]
                 invited_cats.extend(additional_kits)
                 invited_cats.extend(additional_mates)
-                invited_cats = [outsider_cat.ID]
                 
                 for cat_ID in invited_cats:
                     invited_cat = Cat.fetch_cat(cat_ID)


### PR DESCRIPTION
### Motivation
- Prevent a `TypeError` when `invited_cats.extend(...)` is called with a `None` value by ensuring mate and kit collections are always iterable. 
- Ensure outsider mates are properly added to the clan and tracked as IDs instead of mixing object references and list reassignments. 
- Preserve and correctly populate `involved_cats` and `invited_cats` so downstream logic iterates the intended IDs.

### Description
- Initialize `additional_mates` and `additional_kits` as empty lists (`[]`) instead of `None` to guarantee iterability for `extend`. 
- For each eligible mate, call `mate.add_to_clan()` and append `mate.ID` to `additional_mates` so the list holds IDs, not objects. 
- Extend `involved_cats` with `additional_mates` when mates are present instead of iterating an incorrect list. 
- Remove an accidental reset of `invited_cats` so the full invited list (`outsider_cat.ID`, kits, mates) is preserved for further processing.

### Testing
- Compiled the updated module with `python -m compileall /workspace/clangen/scripts/events.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fc9eecc90832ca9cb1b1521dd54a2)