### PR TITLE
Skip female rarity gender rerolls for `can_birth` event cats

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -226,6 +226,7 @@ class Cat:
         self.no_kits = False
         self.no_mates = False
         self.no_retire = False
+        self.skip_female_rarity_roll = kwargs.get("skip_female_rarity_roll", False)
 
         self.prevent_fading = False  # Prevents a cat from fading
 
@@ -572,7 +573,9 @@ class Cat:
             
             if not allow_female_ginger and not allow_tortie_instead and not only_female_torties:
                 # If this is a ginger she-cat spawned randomly out of the wild, apply 20% rule - only 20% of ginger cats are female
-                if random_module.randint(1, 5) != 1:
+                if self.skip_female_rarity_roll:
+                    print("Event can_birth cat keeps female rarity-restricted pelt")
+                elif random_module.randint(1, 5) != 1:
                     self.gender = "male"
                     self.genderalign = "male"
                     print("Regular orange tomcat :)")
@@ -585,7 +588,9 @@ class Cat:
             and self.gender == "female"
             and self.pelt.name not in Pelt.torties
         ):
-            if random_module.randint(1, 3) != 1:
+            if self.skip_female_rarity_roll:
+                print("Event can_birth cat keeps female rarity-restricted pelt")
+            elif random_module.randint(1, 3) != 1:
                 self.gender = "male"
                 self.genderalign = "male"
             

--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -619,6 +619,7 @@ def create_new_cat(
             parent1=parent1,
             parent2=parent2,
             adoptive_parents=adoptive_parents if adoptive_parents else [],
+            skip_female_rarity_roll="can_birth" in attribute_list,
         )
         # this simulates a "history" as whomever they used to be
         new_cat.status.change_current_moons_as(moons)


### PR DESCRIPTION
### Motivation
- Event-generated queens (e.g. a loner queen left with kits) that use the `can_birth` attribute should be allowed to remain female even if their pelts are rarity-restricted (ginger/black). 
- Prevent automatic female→male rerolls for those event cats so the event semantics (a mother who can birth) are preserved.

### Description
- Added a `skip_female_rarity_roll` flag to `Cat` generation via `kwargs`, defaulting to `False`, stored as `self.skip_female_rarity_roll` in `Cat`.
- Updated the female-ginger rarity block in `scripts/cat/cats.py` to bypass the 20% female→male reroll when `self.skip_female_rarity_roll` is true.
- Updated the black she-cat rarity block in `scripts/cat/cats.py` to similarly bypass its male-reroll when the flag is set.
- Wired event creation in `scripts/events_module/consequences.py` to pass `skip_female_rarity_roll=True` when the new-cat `attribute_list` contains `can_birth`.

### Testing
- Compiled the modified modules with `python -m py_compile scripts/cat/cats.py scripts/events_module/consequences.py` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996570a67f4832c9a222201dda4ac90)