### PR TITLE
Fix NameError and wire `skip_female_rarity_roll` for event cats

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -226,6 +226,7 @@ class Cat:
         self.no_kits = False
         self.no_mates = False
         self.no_retire = False
+        self.skip_female_rarity_roll = kwargs.get("skip_female_rarity_roll", False)
 
         self.prevent_fading = False  # Prevents a cat from fading
 
@@ -572,7 +573,9 @@ class Cat:
             
             if not allow_female_ginger and not allow_tortie_instead and not only_female_torties:
                 # If this is a ginger she-cat spawned randomly out of the wild, apply 20% rule - only 20% of ginger cats are female
-                if random_module.randint(1, 5) != 1:
+                if self.skip_female_rarity_roll:
+                    print("Event can_birth cat keeps female rarity-restricted pelt")
+                elif random_module.randint(1, 5) != 1:
                     self.gender = "male"
                     self.genderalign = "male"
                     print("Regular orange tomcat :)")
@@ -585,7 +588,9 @@ class Cat:
             and self.gender == "female"
             and self.pelt.name not in Pelt.torties
         ):
-            if random_module.randint(1, 3) != 1:
+            if self.skip_female_rarity_roll:
+                print("Event can_birth cat keeps female rarity-restricted pelt")
+            elif random_module.randint(1, 3) != 1:
                 self.gender = "male"
                 self.genderalign = "male"
             

--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -406,6 +406,7 @@ def create_new_cat_block(
             parent1=parent1.ID if parent1 else None,
             parent2=parent2.ID if parent2 else None,
             adoptive_parents=adoptive_parents if adoptive_parents else None,
+            skip_female_rarity_roll="can_birth" in attribute_list,
         )
 
         # NEXT
@@ -513,6 +514,7 @@ def create_new_cat(
     parent1: str = None,
     parent2: str = None,
     adoptive_parents: list = None,
+    skip_female_rarity_roll: bool = False,
 ) -> list:
     """
     This function creates new cats and then returns a list of those cats
@@ -619,6 +621,7 @@ def create_new_cat(
             parent1=parent1,
             parent2=parent2,
             adoptive_parents=adoptive_parents if adoptive_parents else [],
+            skip_female_rarity_roll=skip_female_rarity_roll,
         )
         # this simulates a "history" as whomever they used to be
         new_cat.status.change_current_moons_as(moons)


### PR DESCRIPTION
### Motivation
- Event-generated queens with `can_birth` should keep female rarity-restricted pelts without causing a crash, and the previous change accidentally referenced `attribute_list` out of scope causing a `NameError`.

### Description
- Add `self.skip_female_rarity_roll = kwargs.get("skip_female_rarity_roll", False)` to `Cat` so the instance can bypass female-rarity gender rerolls in `scripts/cat/cats.py`.
- Update the ginger/black female rarity checks in `scripts/cat/cats.py` to first respect `self.skip_female_rarity_roll` and only apply the random male-reroll when the flag is false.
- Add a `skip_female_rarity_roll: bool = False` parameter to `create_new_cat(...)` in `scripts/events_module/consequences.py` and forward it into the `Cat(...)` constructor.
- Compute `skip_female_rarity_roll = "can_birth" in attribute_list` in the scope where `attribute_list` exists (the caller that builds the new-cat block) and pass that boolean into `create_new_cat(...)`, removing the out-of-scope reference.

### Testing
- Ran `python -m py_compile scripts/events_module/consequences.py scripts/cat/cats.py` and the files compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996570a67f4832c9a222201dda4ac90)