### PR TITLE
Fix deafness generation randint crash for new cats

### DIFF
--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -779,16 +779,22 @@ def create_new_cat(
             deaf_chance = None
             partial_deaf_chance = None
             if (new_cat.pelt.colour == "WHITE" or new_cat.pelt.white_patches == "FULLWHITE") and new_cat.pelt.eye_colour in blue_eyes:
-                deaf_chance = constants.CONFIG["cat_generation"]["base_permanent_condition"] * 0.4
+                deaf_chance = int(
+                    constants.CONFIG["cat_generation"]["base_permanent_condition"]
+                    * 0.4
+                )
             elif (new_cat.pelt.colour == "WHITE" or new_cat.pelt.white_patches == "FULLWHITE") and new_cat.pelt.eye_colour2 and new_cat.pelt.eye_colour2 in blue_eyes:
-                partial_deaf_chance = constants.CONFIG["cat_generation"]["base_permanent_condition"] * 0.7
+                partial_deaf_chance = int(
+                    constants.CONFIG["cat_generation"]["base_permanent_condition"]
+                    * 0.7
+                )
 
             if deaf_chance:
                 if not random_module.randint(1, deaf_chance):
                     chosen_condition = ("deaf")
                     new_cat.get_permanent_condition(chosen_condition, born_with=True)
             elif partial_deaf_chance:
-                if not random_module.randint(1, deaf_chance):
+                if not random_module.randint(1, partial_deaf_chance):
                     chosen_condition = ("partial hearing loss")
                     new_cat.get_permanent_condition(chosen_condition, born_with=True)
 


### PR DESCRIPTION
### Motivation
- Prevent a `TypeError: 'float' object cannot be interpreted as an integer` raised when `random.randint` was called with float bounds during new cat creation.
- Correct the logic for the partial-hearing-loss roll which incorrectly referenced `deaf_chance`.

### Description
- Cast the computed `deaf_chance` and `partial_deaf_chance` values to `int` before passing them to `random_module.randint` in `scripts/events_module/consequences.py`.
- Fix the partial-hearing-loss branch to use `partial_deaf_chance` for its `randint` call instead of `deaf_chance`.
- Changes are limited to the deafness chance calculation and roll logic in `create_new_cat`.

### Testing
- Ran `python -m py_compile scripts/events_module/consequences.py` to verify syntax, and it succeeded.
- Ran `python -m pytest tests/test_json.py -q`, which failed in this environment due to a missing dependency (`ujson`), so full test suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69967c7c8398832c8eac179eb358abcb)