### PR TITLE
Require warrior mentors to be at least 24 moons old

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2639,6 +2639,11 @@ class Cat:
         ):
             return False
         if (
+            self.status.rank == CatRank.APPRENTICE
+            and potential_mentor.moons < 24
+        ):
+            return False
+        if (
             self.status.rank == CatRank.MEDIATOR_APPRENTICE
             and potential_mentor.status.rank != CatRank.MEDIATOR
         ):

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -436,6 +436,27 @@ class TestUpdateMentor(unittest.TestCase):
         self.assertIsNone(app.mentor)
 
 
+    def test_warrior_mentor_must_be_at_least_24_moons(self):
+        app = Cat(
+            moons=7, status_dict={"rank": CatRank.APPRENTICE}, disable_random=True
+        )
+        young_mentor = Cat(
+            moons=23, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        )
+
+        self.assertFalse(app.is_valid_mentor(young_mentor))
+
+    def test_warrior_mentor_eligible_at_24_moons(self):
+        app = Cat(
+            moons=7, status_dict={"rank": CatRank.APPRENTICE}, disable_random=True
+        )
+        mentor = Cat(
+            moons=24, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        )
+
+        self.assertTrue(app.is_valid_mentor(mentor))
+
+
 class TestNameRepr(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
### Motivation
- Ensure regular apprentices are only assigned warrior mentors who are sufficiently mature by enforcing a minimum age requirement for warrior mentors.

### Description
- Added an age check in `Cat.is_valid_mentor` (`scripts/cat/cats.py`) that returns `False` when `self.status.rank == CatRank.APPRENTICE` and `potential_mentor.moons < 24`.
- Added two unit tests in `tests/test_cat.py` that assert a 23-moon warrior is rejected and a 24-moon warrior is accepted as a mentor.

### Testing
- Compiled the modified files with `python -m compileall scripts/cat/cats.py tests/test_cat.py` which succeeded.
- Attempted `pytest -q tests/test_cat.py -k "mentor"` but test collection failed due to a missing dependency (`ModuleNotFoundError: No module named 'pygame'`), so the new tests were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a206a804a0832c8a866e8468503844)