### PR TITLE
Refine deputy selection using leader respect and weighted odds

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -2562,9 +2562,66 @@ def check_and_promote_deputy():
             )
         )
 
+        # If the leader is present, only include warriors they highly respect.
+        leader = game.clan.leader
+        if leader and leader.status.alive_in_player_clan:
+            possible_deputies = [
+                cat
+                for cat in possible_deputies
+                if leader.relationships.get(cat.ID)
+                and leader.relationships[cat.ID].respect > 30
+            ]
+
         # If there are possible deputies, choose from that list.
         if possible_deputies:
-            random_cat = random.choice(possible_deputies)
+            living_clan_cats = [
+                cat for cat in Cat.all_cats_list if cat.status.alive_in_player_clan
+            ]
+
+            def get_deputy_weight(candidate):
+                """Calculate weighted chance for a warrior to become deputy."""
+                weight = 1
+
+                if len(candidate.former_apprentices) >= 2:
+                    weight += 2
+
+                # Gauge how many clanmates respect this cat and how close that
+                # respect is to the ideal amount.
+                respect_values = []
+                respected_by_count = 0
+                for clanmate in living_clan_cats:
+                    if clanmate.ID == candidate.ID:
+                        continue
+
+                    relation = clanmate.relationships.get(candidate.ID)
+                    respect = relation.respect if relation else 0
+                    respect_values.append(respect)
+
+                    if respect >= 15:
+                        respected_by_count += 1
+
+                if respect_values:
+                    average_respect = sum(respect_values) / len(respect_values)
+                else:
+                    average_respect = 0
+
+                one_third_threshold = max(1, len(living_clan_cats) // 3)
+                one_half_threshold = max(1, len(living_clan_cats) // 2)
+
+                if average_respect >= 20 and respected_by_count >= one_third_threshold:
+                    weight += 2
+
+                if average_respect >= 20 and respected_by_count >= one_half_threshold:
+                    weight += 2
+
+                if average_respect >= 15:
+                    respect_target_bonus = max(0, 5 - int(abs(average_respect - 20) // 2))
+                    weight += respect_target_bonus
+
+                return weight
+
+            deputy_weights = [get_deputy_weight(cat) for cat in possible_deputies]
+            random_cat = random.choices(possible_deputies, weights=deputy_weights, k=1)[0]
             involved_cats = [random_cat.ID]
 
             # Gather deputy and leader status, for determination of the text.


### PR DESCRIPTION
### Motivation
- Ensure a deputy has a good relationship with the leader by gating candidates on leader-to-candidate respect when the leader is present.  
- Give higher deputy odds to cats who have mentored apprentices and who are broadly respected by the clan, so the selection feels more realistic.  
- Provide a tunable, weighted selection that favors candidates with average respect near a target value rather than a uniform random pick.

### Description
- Updated `scripts/events.py` to filter `possible_deputies` so that when `game.clan.leader` is present and alive only warriors for whom `leader.relationships[cat.ID].respect > 30` are considered.  
- Replaced the uniform pick `random.choice(possible_deputies)` with a weighted selection using `random.choices` and a new `get_deputy_weight` function.  
- `get_deputy_weight` adds bonuses for `len(candidate.former_apprentices) >= 2`, for being respected (>=15) by a sizable fraction of living clanmates when the average received respect is high enough, and a bonus when average respect is close to an ideal target (20).  
- Added logic to compute per-candidate average respect from living clanmates and thresholds for one-third and one-half of the clan to influence the weight.

### Testing
- Successfully compiled the modified file with `python -m py_compile /workspace/clangen/scripts/events.py` (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a20cad27b4832c91a8057d8049df41)