### PR TITLE
Prefer leader‑respected cats and mentor experience when choosing deputy

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -2562,9 +2562,37 @@ def check_and_promote_deputy():
             )
         )
 
+        # If the leader is present, prioritize warriors they highly respect.
+        leader = game.clan.leader
+        use_mentor_weighting = False
+        if leader and leader.status.alive_in_player_clan:
+            respected_deputies = [
+                cat
+                for cat in possible_deputies
+                if leader.relationships.get(cat.ID)
+                and leader.relationships[cat.ID].respect >= 20
+            ]
+
+            if respected_deputies:
+                possible_deputies = respected_deputies
+            else:
+                # If no one is respected enough, give a slight edge to experienced mentors.
+                use_mentor_weighting = True
+
         # If there are possible deputies, choose from that list.
         if possible_deputies:
-            random_cat = random.choice(possible_deputies)
+            if use_mentor_weighting:
+                deputy_weights = [
+                    2 if len(cat.former_apprentices) >= 2 else 1
+                    for cat in possible_deputies
+                ]
+                random_cat = random.choices(
+                    possible_deputies,
+                    weights=deputy_weights,
+                    k=1,
+                )[0]
+            else:
+                random_cat = random.choice(possible_deputies)
             involved_cats = [random_cat.ID]
 
             # Gather deputy and leader status, for determination of the text.


### PR DESCRIPTION
### Motivation

- Improve deputy selection so the leader's preferences and mentoring experience influence the choice when appointing a new deputy.

### Description

- Update `check_and_promote_deputy` in `scripts/events.py` to, when the leader is present and alive, prefer candidates the leader respects (relationship respect >= 20). 
- If no sufficiently respected candidates exist, enable a mentor weighting heuristic that gives cats with two or more `former_apprentices` a higher selection weight.
- Use `random.choices` with weights when mentor weighting is enabled and preserve the original `random.choice` behavior otherwise.

### Testing

- Ran the project's automated test suite and linters against the modified code and they completed successfully.
- Performed a smoke test of `check_and_promote_deputy` scenarios (leader present/respected, leader present/unrespected, leader absent) to verify selection behavior matches expected prioritization.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a20cad27b4832c91a8057d8049df41)