### PR TITLE
Fix Discord Rich Presence not clearing on game exit

### DIFF
--- a/scripts/game_structure/discord_rpc.py
+++ b/scripts/game_structure/discord_rpc.py
@@ -44,9 +44,10 @@ class _DiscordRPC(threading.Thread):
     def run(self):
         self.start_rpc.wait()
         self.get_rpc()
-        self.connect()
         while not self.close_rpc.is_set():
-            self.update_rpc.wait()
+            self.update_rpc.wait(1)
+            if self.close_rpc.is_set():
+                break
             self.update()
         self.close()
 
@@ -144,6 +145,17 @@ class _DiscordRPC(threading.Thread):
         self.update_rpc.clear()
 
     def close(self):
-        if self._connected:
-            self._rpc.close()
-            self._connected = False
+        if self._rpc:
+            try:
+                self._rpc.clear()
+            except BaseException:  # pylint: disable=broad-except
+                pass
+
+            try:
+                self._rpc.close()
+            except BaseException:  # pylint: disable=broad-except
+                pass
+
+        self._connected = False
+        self._rpc_supported = False
+        self._rpc = None


### PR DESCRIPTION
### Motivation
- Discord Rich Presence sometimes remained visible after quitting the game; the RPC thread shutdown and close path needed to reliably clear activity and stop promptly.

### Description
- Update `_DiscordRPC.run` to wake periodically (`update_rpc.wait(1)`) and break if `close_rpc` is set, remove the redundant `connect()` call in `run()`, and make `close()` explicitly call `self._rpc.clear()` then `self._rpc.close()` while safely handling exceptions and resetting internal flags (`_connected`, `_rpc_supported`, `_rpc`).

### Testing
- Compiled the modified modules with `python -m compileall scripts/game_structure/discord_rpc.py scripts/housekeeping/quit_game.py` (succeeded); running `pytest -q` in this environment failed during collection due to missing runtime dependencies (`pygame`, `ujson`, `i18n`, `pydantic`, `strenum`) so full test-suite validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a315584248832cb5d560b8053ab539)