### PR TITLE
Fix old-age pair death events selecting underage mates

### DIFF
--- a/scripts/events_module/short/short_event_generation.py
+++ b/scripts/events_module/short/short_event_generation.py
@@ -606,6 +606,16 @@ def filter_events(
             failed_ids.append(chosen_event.event_id)
             final_events.remove(chosen_event)
             chosen_event = None
+        elif (
+            "old_age" in chosen_event.sub_type
+            and chosen_event.r_c.get("dies", False)
+            and chosen_cat.moons
+            < constants.CONFIG["death_related"]["old_age_death_start"]
+        ):
+            failed_ids.append(chosen_event.event_id)
+            final_events.remove(chosen_event)
+            chosen_event = None
+            chosen_cat = None
         else:
             break
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -8,7 +8,7 @@ import os
 
 from scripts.cat import save_load
 from scripts.cat.cats import create_cat, Cat
-from scripts.cat.enums import CatRank
+from scripts.cat.enums import CatAge, CatRank
 from scripts.cat.sprites.load_sprites import sprites
 from scripts.clan import Clan, Afterlife
 from scripts.clan_package.settings import set_clan_setting
@@ -16,6 +16,7 @@ from scripts import events
 from scripts.events_module.short.short_event_generation import (
     filter_events,
 )
+from scripts.events_module.short.short_event import ShortEvent
 from scripts.game_structure import game
 from scripts.clan_package.get_clan_cats import (
     get_living_clan_cat_count,
@@ -141,3 +142,40 @@ class TestEvents(unittest.TestCase):
 
                 if not _ % 100:
                     print(f"CLANCATS ALIVE: {get_living_clan_cat_count(Cat)}")
+
+    def test_old_age_events_require_old_enough_random_cat(self):
+        """
+        Old-age events that kill r_c should not select r_c cats below the old-age threshold.
+        """
+        main_cat = create_cat(CatRank.ELDER)
+        random_cat = create_cat(CatRank.ELDER)
+        game.clan.add_cat(main_cat)
+        game.clan.add_cat(random_cat)
+
+        main_cat.moons = 160
+        random_cat.moons = 132
+        main_cat.age = CatAge.SENIOR
+        random_cat.age = CatAge.SENIOR
+        main_cat.set_mate(random_cat)
+
+        old_age_event = ShortEvent(
+            event_id="test_old_age_double_death",
+            sub_type=["old_age"],
+            m_c={"age": ["senior"], "status": ["any"], "relationship_status": ["mates"], "dies": True},
+            r_c={"age": ["senior"], "status": ["any"], "dies": True},
+        )
+
+        chosen_event, chosen_random_cat = filter_events(
+            possible_events=[old_age_event],
+            main_cat=main_cat,
+            random_cat=None,
+            other_clan=game.clan.all_other_clans[0],
+            sub_types=["old_age"],
+            allowed_events=None,
+            excluded_events=None,
+            ignore_subtyping=False,
+            reduction_avoidance_chance=1,
+        )
+
+        self.assertIsNone(chosen_event)
+        self.assertIsNone(chosen_random_cat)


### PR DESCRIPTION
### Motivation
- The `gen_death_age_any5`/old-age pair-death path could select an `r_c` mate that is younger than the configured `old_age_death_start` (e.g. < 150 moons), producing incorrect double-death events. 
- Ensure old-age events that mark the random cat to die only proceed when the chosen `r_c` meets the configured old-age threshold.

### Description
- Add a post-selection guard in `filter_events` to discard a chosen event when `"old_age" in chosen_event.sub_type`, `chosen_event.r_c.get("dies", False)` is true, and the selected `chosen_cat.moons` is below `constants.CONFIG["death_related"]["old_age_death_start"]`, preventing underage mates from being used. (`scripts/events_module/short/short_event_generation.py`)
- Add a regression unit test `test_old_age_events_require_old_enough_random_cat` that constructs an old-age pair-death `ShortEvent` with a mate at 132 moons and verifies no event or random cat is selected. (`tests/test_events.py`)
- Import `ShortEvent` and `CatAge` in the test file to build the test event and set ages correctly. (`tests/test_events.py`)

### Testing
- Ran `python -m compileall scripts/events_module/short/short_event_generation.py tests/test_events.py` which succeeded. 
- Ran `pytest -q tests/test_events.py -k old_age_events_require_old_enough_random_cat` but test collection failed in this environment due to a missing dependency (`ModuleNotFoundError: No module named 'ujson'`).
- The change is covered by a new unit test which should pass in a fully provisioned environment with project dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a319e8de78832c8bec44fb68b6db5b)