### PR TITLE
Improve Discord RPC robustness; fix start time and cat counting

### DIFF
--- a/scripts/game_structure/discord_rpc.py
+++ b/scripts/game_structure/discord_rpc.py
@@ -11,6 +11,8 @@ import asyncio
 import threading
 from time import time
 
+from scripts.cat.cats import Cat
+
 from scripts.game_structure.game.settings import game_setting_get
 from scripts.game_structure.game.switches import switch_get_value, Switch
 from scripts.game_structure import game
@@ -33,7 +35,7 @@ class _DiscordRPC(threading.Thread):
         self._rpc = None
         self._client_id = client_id
         self._connected = False
-        self._start_time = round(time() * 1000)
+        self._start_time = int(time())
         self._rpc_supported = False
         self._event_loop = asyncio.new_event_loop()
 
@@ -44,9 +46,10 @@ class _DiscordRPC(threading.Thread):
     def run(self):
         self.start_rpc.wait()
         self.get_rpc()
-        self.connect()
         while not self.close_rpc.is_set():
-            self.update_rpc.wait()
+            self.update_rpc.wait(1)
+            if self.close_rpc.is_set():
+                break
             self.update()
         self.close()
 
@@ -114,7 +117,9 @@ class _DiscordRPC(threading.Thread):
 
             if game.clan:
                 clan_name = f"{game.clan.displayname}Clan"
-                cats_amount = len(game.clan.clan_cats)
+                cats_amount = sum(
+                    1 for cat in Cat.all_cats.values() if cat.status.alive_in_player_clan
+                )
                 clan_age = game.clan.age
             else:
                 clan_name = "Loading..."
@@ -144,6 +149,17 @@ class _DiscordRPC(threading.Thread):
         self.update_rpc.clear()
 
     def close(self):
-        if self._connected:
-            self._rpc.close()
-            self._connected = False
+        if self._rpc:
+            try:
+                self._rpc.clear()
+            except BaseException:  # pylint: disable=broad-except
+                pass
+
+            try:
+                self._rpc.close()
+            except BaseException:  # pylint: disable=broad-except
+                pass
+
+        self._connected = False
+        self._rpc_supported = False
+        self._rpc = None


### PR DESCRIPTION
### Motivation
- Make the Discord Rich Presence integration more robust against missing/closing RPC connections and during shutdown.
- Fix an incorrect cat count that previously used the clan list and ensure the presence shows alive player-clan cats only.
- Normalize the RPC start time representation to a simpler integer timestamp.

### Description
- Import `Cat` and compute the displayed cat count using `sum(1 for cat in Cat.all_cats.values() if cat.status.alive_in_player_clan)` instead of `len(game.clan.clan_cats)` to reflect alive cats in the player clan.
- Change `_start_time` from `round(time() * 1000)` to `int(time())` to use a consistent integer timestamp.
- Make the RPC thread loop non-blocking on shutdown by using `self.update_rpc.wait(1)` and checking `self.close_rpc` to allow timely exit; remove the direct `connect()` call after `get_rpc()`.
- Harden `close()` to call `self._rpc.clear()` and `self._rpc.close()` inside `try/except` blocks and reset `_connected`, `_rpc_supported`, and `_rpc` to safe defaults.

### Testing
- Ran the project test suite with `pytest` and all tests passed.
- Ran `flake8` lint checks and no new issues were reported.
- Executed an automated headless smoke test of the RPC update path with `pypresence` mocked and observed no exceptions during update and shutdown.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a315584248832cb5d560b8053ab539)