### PR TITLE
Ensure young outsiders receive loner names and retain outsider prefix when joining

### DIFF
--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -650,12 +650,17 @@ def create_new_cat(
         if (
             kit or litter or moons < 12
         ) and original_group not in game.clan.other_clan_IDs:
-            if new_cat.status.is_outsider:
-                if bool(getrandbits(1)):
-                    name = choice(names.names_dict["loner_names"])
-                    # otherwise give name from prefix list (more nature-y names)
+            if original_social in (CatSocial.LONER, CatSocial.KITTYPET, CatSocial.ROGUE):
+                # young outsiders always receive a loner-style name while they are outside the Clan
+                name = choice(names.names_dict["loner_names"])
+                if new_cat.status.is_outsider:
+                    new_cat.change_name(new_prefix=name, new_suffix="")
                 else:
-                    name = choice(names.names_dict["normal_prefixes"])
+                    # if they join, keep their original outsider name as the prefix and add
+                    # a Clan suffix that remains hidden behind special rank suffixes (-kit/-paw)
+                    new_cat.change_name(new_prefix=name)
+                    new_cat.specsuffix_hidden = False
+                    new_cat.name.specsuffix_hidden = False
             else:
                 # babies change name, in case their initial name isn't clan-ish
                 new_cat.change_name()


### PR DESCRIPTION
### Motivation
- Young cats (kit, litter, or <12 moons) generated as outsiders should receive loner-style names while outside the Clan, and if they immediately join the Clan their original outsider name should be preserved as the prefix while a Clan suffix is applied and special-suffix visibility is adjusted.

### Description
- Updated naming logic in `scripts/events_module/consequences.py` to detect young outsiders (`kit or litter or moons < 12`) and use `names.names_dict["loner_names"]` for `original_social` values `(CatSocial.LONER, CatSocial.KITTYPET, CatSocial.ROGUE)`.
- If the generated cat remains an outsider, call `change_name(new_prefix=name, new_suffix="")` so they keep a loner-style name while outside the Clan.
- If the young outsider joins the Clan immediately, call `change_name(new_prefix=name)` and enable special-suffix visibility (`new_cat.specsuffix_hidden = False` and `new_cat.name.specsuffix_hidden = False`) so the generated Clan suffix can be handled/hidden by `-kit` / `-paw` special suffix behavior.
- Change is localized to `scripts/events_module/consequences.py` (naming & join handling).

### Testing
- Ran `python -m py_compile scripts/events_module/consequences.py` and the file compiled successfully.
- Ran `python -m pytest tests/test_cat.py -k "name" -q` which could not run in this environment due to missing dependency `pygame` (test collection failed with `ModuleNotFoundError: No module named 'pygame'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a47090c760832ca6a6eb8c05363225)