### PR TITLE
Prefer opposite‑gender partners on same‑sex balance and boost high‑romance monthly interactions

### DIFF
--- a/scripts/events_module/relationship/relation_events.py
+++ b/scripts/events_module/relationship/relation_events.py
@@ -54,7 +54,20 @@ class Relation_Events:
         Relation_Events.same_age_events(cat)
 
         # 1/16 for an additional event
-        if not random.getrandbits(4):
+        trigger_romantic_event = not random.getrandbits(4)
+
+        # cats with strong romantic feelings have a much higher chance of having
+        # a romantic interaction in a moon
+        if not trigger_romantic_event:
+            has_high_romance_interest = any(
+                relationship.romance > 25
+                and relationship.cat_to.status.alive_in_player_clan
+                for relationship in cat.relationships.values()
+            )
+            if has_high_romance_interest and random_module.random() < 0.75:
+                trigger_romantic_event = True
+
+        if trigger_romantic_event:
             Relation_Events.romantic_events(cat)
 
         RomanticEvents.handle_mating_and_breakup(cat)
@@ -88,6 +101,9 @@ class Relation_Events:
 
         # only adding cats which already have SOME relationship with each other
         cat_to_choose_from = []
+        opposite_gender_fallback = []
+        high_romance_options = []
+        same_sex_balance_blocked = False
         for inter_cat in possible_cats:
             # toss out cats who are outside
             if inter_cat.status.is_outsider:
@@ -106,8 +122,22 @@ class Relation_Events:
                 inter_cat.relationships[cat.ID].like > 10
                 or inter_cat.relationships[cat.ID].comfort > 10
             )
+
+            if cat_to_inter and inter_to_cat and inter_cat.gender != cat.gender:
+                opposite_gender_fallback.append(inter_cat)
+
+            if (
+                cat_to_inter
+                and inter_to_cat
+                and (
+                    cat.relationships[inter_cat.ID].romance > 25
+                    or inter_cat.relationships[cat.ID].romance > 25
+                )
+            ):
+                high_romance_options.append(inter_cat)
             
-            if cat.gender == inter_cat.gender and random_module.randint(1, 10500) != 1 and not (inter_cat.relationships[cat.ID].romance > 0 or inter_cat.relationships[cat.ID].romance > 0):
+            if cat.gender == inter_cat.gender and random_module.randint(1, 10500) != 1 and not (cat.relationships[inter_cat.ID].romance > 0 or inter_cat.relationships[cat.ID].romance > 0):
+                same_sex_balance_blocked = True
                 continue # balancing same-sex relationships - there are too many and I just want more kits in my clans, sorry >:(
             
             if cat_to_inter and inter_to_cat:
@@ -133,10 +163,29 @@ class Relation_Events:
                 if cat.all_cats[mate_id].status.alive_in_player_clan
             ]
 
+        if same_sex_balance_blocked and opposite_gender_fallback:
+            cat_to_choose_from = [
+                inter_cat
+                for inter_cat in cat_to_choose_from
+                if inter_cat.gender != cat.gender
+            ]
+            if not cat_to_choose_from:
+                cat_to_choose_from = opposite_gender_fallback
+
         if not cat_to_choose_from:
             return
 
-        other_cat = choice(cat_to_choose_from)
+        if high_romance_options:
+            high_romance_choices = [
+                inter_cat for inter_cat in high_romance_options if inter_cat in cat_to_choose_from
+            ]
+            if high_romance_choices and random_module.random() < 0.75:
+                other_cat = choice(high_romance_choices)
+            else:
+                other_cat = choice(cat_to_choose_from)
+        else:
+            other_cat = choice(cat_to_choose_from)
+
         if RomanticEvents.start_interaction(cat, other_cat):
             Relation_Events.trigger_event(cat)
             Relation_Events.trigger_event(other_cat)

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -180,7 +180,55 @@ class RomanticEvents:
             return False
 
         if cat_from.gender == cat_to.gender and cat_to.ID not in cat_from.mate and random_module.randint(1, 10500) != 1:
-            return False # balancing same-sex relationships - there are too many and I just want more kits in my clans, sorry >:(
+            opposite_gender_candidates = [
+                inter_cat
+                for inter_cat in cat_from.all_cats.values()
+                if inter_cat.status.alive_in_player_clan
+                and inter_cat.ID != cat_from.ID
+                and inter_cat.ID in cat_from.relationships
+                and inter_cat.gender != cat_from.gender
+                and inter_cat.is_potential_mate(cat_from, for_love_interest=True)
+                and (
+                    cat_from.relationships[inter_cat.ID].like > 10
+                    or cat_from.relationships[inter_cat.ID].comfort > 10
+                )
+                and (
+                    inter_cat.relationships[cat_from.ID].like > 10
+                    or inter_cat.relationships[cat_from.ID].comfort > 10
+                )
+            ]
+
+            if cat_from.mate:
+                opposite_gender_mates = [
+                    cat_from.all_cats[mate_id]
+                    for mate_id in cat_from.mate
+                    if mate_id in cat_from.all_cats
+                    and cat_from.all_cats[mate_id].status.alive_in_player_clan
+                    and cat_from.all_cats[mate_id].gender != cat_from.gender
+                    and mate_id in cat_from.relationships
+                    and cat_from.relationships[mate_id].romance > 25
+                ]
+                if opposite_gender_mates:
+                    opposite_gender_candidates = opposite_gender_mates
+
+            if opposite_gender_candidates:
+                cat_to = choice(opposite_gender_candidates)
+                if cat_to.ID in cat_from.mate and not cat_to.dead:
+                    relevant_dict = deepcopy(RomanticEvents.MATE_INTERACTIONS)
+                else:
+                    relevant_dict = deepcopy(RomanticEvents.ROMANTIC_INTERACTIONS)
+                relationship = cat_from.relationships[cat_to.ID]
+                positive = relationship.positive_interaction()
+                possible_interactions = (
+                    relevant_dict["positive"] if positive else relevant_dict["negative"]
+                )
+                filtered_interactions = relationship.get_relevant_interactions(
+                    possible_interactions
+                )
+                if not filtered_interactions:
+                    return False
+            else:
+                return False # balancing same-sex relationships - there are too many and I just want more kits in my clans, sorry >:(
         
         # chose interaction
         chosen_interaction = choice(filtered_interactions)

--- a/tests/test_romantic_events.py
+++ b/tests/test_romantic_events.py
@@ -1,10 +1,12 @@
 import os
 import unittest
+from unittest.mock import patch
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
 from scripts.cat.cats import Cat, Relationship
+from scripts.events_module.relationship.relation_events import Relation_Events
 from scripts.events_module.relationship.romantic_events import RomanticEvents
 
 
@@ -34,3 +36,71 @@ class RelationshipConditions(unittest.TestCase):
         self.assertTrue(
             RomanticEvents.relationship_fulfill_condition(rel_fulfill, condition)
         )
+
+
+class RomanticEventSelection(unittest.TestCase):
+    @patch("scripts.events_module.relationship.relation_events.RomanticEvents.handle_mating_and_breakup")
+    @patch("scripts.events_module.relationship.relation_events.Relation_Events.romantic_events")
+    @patch("scripts.events_module.relationship.relation_events.Relation_Events.same_age_events")
+    @patch("scripts.events_module.relationship.relation_events.Relation_Events.group_events")
+    @patch("scripts.events_module.relationship.relation_events.random_module.random")
+    @patch("scripts.events_module.relationship.relation_events.random.getrandbits")
+    def test_high_romance_boosts_monthly_interaction_chance(
+        self,
+        mock_getrandbits,
+        mock_random,
+        mock_group_events,
+        mock_same_age_events,
+        mock_romantic_events,
+        mock_handle_mating,
+    ):
+        cat_1 = Cat(gender="female", moons=30, disable_random=True)
+        cat_2 = Cat(gender="male", moons=30, disable_random=True)
+        relationship = Relationship(cat_1, cat_2)
+        relationship.romance = 30
+        cat_1.relationships[cat_2.ID] = relationship
+
+        mock_getrandbits.return_value = 1
+        mock_random.return_value = 0.1
+
+        Relation_Events.handle_relationships(cat_1)
+
+        mock_romantic_events.assert_called_once_with(cat_1)
+
+    @patch("scripts.events_module.relationship.relation_events.Relation_Events.can_trigger_events", return_value=True)
+    @patch("scripts.events_module.relationship.relation_events.RomanticEvents.start_interaction", return_value=False)
+    @patch("scripts.events_module.relationship.relation_events.get_possible_mates")
+    @patch("scripts.events_module.relationship.relation_events.random_module.randint", return_value=2)
+    def test_same_sex_balance_falls_back_to_opposite_gender_candidate(
+        self,
+        mock_randint,
+        mock_get_possible_mates,
+        mock_start_interaction,
+        mock_can_trigger,
+    ):
+        cat = Cat(gender="female", moons=30, disable_random=True)
+        same_sex_cat = Cat(gender="female", moons=30, disable_random=True)
+        opposite_sex_cat = Cat(gender="male", moons=30, disable_random=True)
+
+        cat.relationships[same_sex_cat.ID] = Relationship(cat, same_sex_cat)
+        same_sex_cat.relationships[cat.ID] = Relationship(same_sex_cat, cat)
+        cat.relationships[opposite_sex_cat.ID] = Relationship(cat, opposite_sex_cat)
+        opposite_sex_cat.relationships[cat.ID] = Relationship(opposite_sex_cat, cat)
+
+        cat.relationships[same_sex_cat.ID].like = 50
+        cat.relationships[same_sex_cat.ID].comfort = 50
+        same_sex_cat.relationships[cat.ID].like = 50
+        same_sex_cat.relationships[cat.ID].comfort = 50
+
+        cat.relationships[opposite_sex_cat.ID].like = 50
+        cat.relationships[opposite_sex_cat.ID].comfort = 50
+        opposite_sex_cat.relationships[cat.ID].like = 50
+        opposite_sex_cat.relationships[cat.ID].comfort = 50
+
+        mock_get_possible_mates.return_value = ([same_sex_cat, opposite_sex_cat], [])
+
+        Relation_Events.romantic_events(cat)
+
+        self.assertTrue(mock_start_interaction.called)
+        called_cat_to = mock_start_interaction.call_args.args[1]
+        self.assertEqual(called_cat_to.gender, "male")


### PR DESCRIPTION
### Motivation
- Reduce silent drops from the same‑sex balancing gate by selecting a valid opposite‑gender romantic target when available, while keeping the existing balancing rule outside `consequences.py` intact.
- Increase the per‑moon chance that cats with strong romantic interest (`romance > 25`) will get a romantic interaction, so high‑romance relationships produce interactions more often.
- Bias selection toward opposite‑gender mates and prioritize opposite‑gender targets with already high romance to make likely partners more likely to be chosen.

### Description
- In `scripts/events_module/relationship/relation_events.py` updated `handle_relationships` so a cat with any relationship having `romance > 25` gains a boosted chance (~75%) to trigger a monthly romantic event in addition to the existing `1/16` roll.
- In `scripts/events_module/relationship/relation_events.py` updated `romantic_events` to collect `opposite_gender_fallback` and `high_romance_options`, mark when a same‑sex candidate was blocked by the `randint(1, 10500)` balancing check, and then pick a valid opposite‑gender candidate (preferring high‑romance targets) instead of silently skipping.
- In `scripts/events_module/relationship/romantic_events.py` changed the same‑sex balancing branch inside `start_interaction` to attempt selecting an opposite‑gender candidate (preferring opposite‑gender mates with `romance > 25`) and refresh the `relevant_dict` accordingly before giving up and returning `False`.
- Added unit tests in `tests/test_romantic_events.py` that assert the high‑romance monthly boost triggers `Relation_Events.romantic_events` and that the same‑sex balancing fallbacks pick an opposite‑gender candidate when available.
- Files changed: `relation_events.py`, `romantic_events.py`, and `tests/test_romantic_events.py`; `consequences.py` was intentionally not modified.

### Testing
- Compiled the modified modules with `python -m compileall scripts/events_module/relationship/relation_events.py scripts/events_module/relationship/romantic_events.py tests/test_romantic_events.py`, which succeeded.
- Ran `pytest -q tests/test_romantic_events.py`, which could not complete in this environment because the `i18n` dependency is missing during test collection and caused an import error. The new tests are included and exercise the added logic but require the runtime dependencies to run successfully in CI/local dev.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac50bbb59c832cb84a851c2fe77ae6)