### PR TITLE
Fix exiled cats default afterlife routing (Dark Forest vs Unknown Residence)

### DIFF
--- a/scripts/cat/status.py
+++ b/scripts/cat/status.py
@@ -573,8 +573,11 @@ class Status:
         go to the unknown residence.
         """
         # if we have an outsider who has never been a clancat, they go to the unknown residence
-        if self.is_outsider and (
-           not self.is_exiled(CatGroup.PLAYER_CLAN_ID) or not self.is_lost(CatGroup.PLAYER_CLAN_ID) or not self.is_former_clancat
+        if (
+            self.is_outsider
+            and not self.is_exiled(CatGroup.PLAYER_CLAN_ID)
+            and not self.is_lost(CatGroup.PLAYER_CLAN_ID)
+            and not self.is_former_clancat
         ):
             return CatGroup.UNKNOWN_RESIDENCE_ID
 

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -712,6 +712,35 @@ class TestNameRepr(unittest.TestCase):
                 self.assertTrue(str(cat.name).endswith("test"))
 
 
+class TestAfterlifeAssignment(unittest.TestCase):
+    def test_default_afterlife_for_exiled_cat(self):
+        exiled_status = {
+            "group_history": [
+                {
+                    "group": CatGroup.PLAYER_CLAN_ID,
+                    "rank": CatRank.WARRIOR,
+                    "moons_as": 1,
+                },
+                {"group": None, "rank": CatRank.LONER, "moons_as": 1},
+            ],
+            "standing_history": [
+                {"group": CatGroup.PLAYER_CLAN_ID, "standing": ["member", "exiled"]}
+            ],
+        }
+
+        cat = Cat(status_dict=exiled_status, disable_random=True)
+
+        self.assertEqual(cat.status.get_default_afterlife_id(), CatGroup.DARK_FOREST_ID)
+
+    def test_default_afterlife_for_true_outsider(self):
+        outsider_cat = Cat(status_dict={"rank": CatRank.ROGUE}, disable_random=True)
+
+        self.assertEqual(
+            outsider_cat.status.get_default_afterlife_id(),
+            CatGroup.UNKNOWN_RESIDENCE_ID,
+        )
+
+
 class TestSocialAssignment(unittest.TestCase):
     def test_clancat_social(self):
         clancat_ranks = (


### PR DESCRIPTION
### Motivation
- Exiled cats were being routed to the Unknown Residence due to an incorrect boolean condition in `get_default_afterlife_id()`, so exiled cats did not go to the Dark Forest as intended.

### Description
- Replace the incorrect mixed `or`/negation condition with an explicit combined check using `and` in `get_default_afterlife_id()` so only true outsiders (never exiled, never lost, never former clancat) return `Unknown Residence`.
- Preserve the branch that sends exiled outsiders to `Dark Forest` when appropriate so exiled cats go to the Dark Forest after death.
- Add regression tests in `tests/test_cat.py` that assert an exiled cat defaults to `CatGroup.DARK_FOREST_ID` and that a true outsider defaults to `CatGroup.UNKNOWN_RESIDENCE_ID`.
- Modified files: `scripts/cat/status.py` and `tests/test_cat.py`.

### Testing
- Compiled the modified modules with `python -m compileall scripts/cat/status.py tests/test_cat.py`, which succeeded.
- Attempted to run the focused tests with `pytest -q tests/test_cat.py -k "AfterlifeAssignment or test_outsiders or test_specsuffix_outsiders"`, but test collection failed due to a missing runtime dependency (`pygame`) in this environment, preventing full pytest validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac55474a00832cb73c83978637d6f5)