### PR TITLE
Handle string relationship effect amounts

### DIFF
--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -996,7 +996,15 @@ def unpack_rel_block(
     for block in relationship_effects:
         cats_from = block.get("cats_from", [])
         cats_to = block.get("cats_to", [])
-        amount = block.get("amount")
+        raw_amount = block.get("amount")
+        try:
+            amount = int(raw_amount)
+        except (TypeError, ValueError):
+            print(
+                "WARNING: relationship effect amount must be numeric, "
+                f"got {raw_amount!r} in block {block}"
+            )
+            continue
         values = [x for x in block.get("values", ()) if x in possible_values]
 
         # if this is a reaction from the entire clan, we need to know for later

--- a/tests/test_handle_short_events.py
+++ b/tests/test_handle_short_events.py
@@ -136,6 +136,32 @@ class TestHandleTransition(unittest.TestCase):
         )
 
 
+class TestHandleRelationships(unittest.TestCase):
+    def setUp(self):
+        self.chosen_event = ShortEvent(
+            event_id="test",
+            r_c={"age": "any"},
+            relationships=[
+                {
+                    "cats_from": ["m_c"],
+                    "cats_to": ["r_c"],
+                    "amount": "10",
+                    "values": ["like"],
+                }
+            ],
+        )
+        self.chosen_event.main_cat = Cat(disable_random=True)
+        self.chosen_event.random_cat = Cat(disable_random=True)
+
+    def test_string_amount_is_coerced_for_relationship_changes(self):
+        self.chosen_event.execute_event()
+
+        relationship = self.chosen_event.main_cat.relationships[
+            self.chosen_event.random_cat.ID
+        ]
+        self.assertEqual(relationship.like, 10)
+
+
 class TestHandleDeath(unittest.TestCase):
     pass
 


### PR DESCRIPTION
### Motivation
- Prevent a crash when relationship effect `amount` values are provided as non-numeric strings (e.g. "10") in event data by making `unpack_rel_block` tolerant of string numbers and malformed values.
- Add a regression test to ensure string-formatted `amount` values are processed correctly.

### Description
- Coerce the raw `amount` from the relationship effect block to an integer by reading `raw_amount = block.get("amount")` and converting with `int(raw_amount)`, and skip the block with a warning on `TypeError`/`ValueError` instead of raising an exception (`scripts/events_module/consequences.py`).
- Add `TestHandleRelationships` to `tests/test_handle_short_events.py` which constructs a `ShortEvent` with a string `"amount"` and asserts the relationship `like` value was updated (test verifies `relationship.like == 10`).

### Testing
- Ran `python -m compileall scripts/events_module/consequences.py tests/test_handle_short_events.py` which succeeded.
- Attempted `python -m pytest tests/test_handle_short_events.py -q` but test collection failed in this environment due to the missing `i18n` dependency (`ModuleNotFoundError: No module named 'i18n'`).
- Committed the changes and verified repository status and diff checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba288f1118832c99fb04d6c36e6169)