### PR TITLE
Ensure unique kit names and add tests for name conflict resolution

### DIFF
--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -85,6 +85,59 @@ class Pregnancy_Events:
         return len(Pregnancy_Events.biggest_family) > (living_cats / 10)
 
     @staticmethod
+    def ensure_unique_kit_name(kit: Cat, litter_kittens, clan=None):
+        biome = None
+        if clan is not None:
+            biome = clan.biome if not clan.override_biome else clan.override_biome
+
+        excluded_ids = {kit.ID, *(kitty.ID for kitty in litter_kittens)}
+        used_prefixes = {kitty.name.prefix for kitty in litter_kittens}
+        used_prefixes.update(
+            cat.name.prefix
+            for cat in Cat.all_cats.values()
+            if cat.ID not in excluded_ids
+            and cat.status.alive_in_player_clan
+            and (
+                cat.status.rank == CatRank.KITTEN
+                or cat.status.rank.is_any_apprentice_rank()
+            )
+        )
+
+        used_full_names = {
+            kitty.name.prefix + kitty.name.suffix for kitty in litter_kittens
+        }
+        used_full_names.update(
+            cat.name.prefix + cat.name.suffix
+            for cat in Cat.all_cats.values()
+            if cat.ID not in excluded_ids and cat.status.alive_in_player_clan
+        )
+
+        max_attempts = max(
+            1,
+            len(Name.names_dict["normal_prefixes"])
+            * len(Name.names_dict["normal_suffixes"]),
+        )
+        for _ in range(max_attempts):
+            if kit.name.prefix in used_prefixes:
+                kit.name = Name(
+                    biome=biome,
+                    specsuffix_hidden=kit.specsuffix_hidden,
+                    cat=kit,
+                )
+                continue
+
+            if kit.name.prefix + kit.name.suffix in used_full_names:
+                kit.name = Name(
+                    prefix=kit.name.prefix,
+                    biome=biome,
+                    specsuffix_hidden=kit.specsuffix_hidden,
+                    cat=kit,
+                )
+                continue
+
+            break
+
+    @staticmethod
     def handle_pregnancy_age(clan):
         """Increase the moon for each pregnancy in the pregnancy dictionary"""
         for pregnancy_key in clan.pregnancy_data.keys():
@@ -1115,9 +1168,7 @@ class Pregnancy_Events:
                     cat.status.social, specific_group=CatGroup.PLAYER_CLAN_ID
                 )
 
-            # Prevent duplicate prefixes in the same litter
-            while kit.name.prefix in [kitty.name.prefix for kitty in all_kitten]:
-                kit.name = Name("newborn")
+            Pregnancy_Events.ensure_unique_kit_name(kit, all_kitten, clan)
 
             all_kitten.append(kit)
             # adoptive parents are set at the end, when everything else is decided

--- a/tests/test_relation_events.py
+++ b/tests/test_relation_events.py
@@ -1,11 +1,13 @@
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
 
 from scripts.cat.cats import Cat
+from scripts.cat.enums import CatRank
+from scripts.cat.names import Name, names
 from scripts.cat_relations.relationship import Relationship
 from scripts.clan import Clan
 from scripts.events_module.relationship.pregnancy_events import Pregnancy_Events
@@ -201,3 +203,68 @@ class Mates(unittest.TestCase):
 
         # then
         self.assertFalse(RomanticEvents.check_if_new_mate(cat1, cat2)[0])
+
+
+class KitNameConflicts(unittest.TestCase):
+    def setUp(self):
+        self.original_all_cats = Cat.all_cats
+        self.original_all_cats_list = Cat.all_cats_list
+        self.original_ordered_cat_list = Cat.ordered_cat_list
+        self.original_outside_cats = Cat.outside_cats
+        self.original_prefix_history = names.prefix_history.copy()
+
+        Cat.all_cats = {}
+        Cat.all_cats_list = []
+        Cat.ordered_cat_list = []
+        Cat.outside_cats = {}
+        names.prefix_history = []
+
+    def tearDown(self):
+        Cat.all_cats = self.original_all_cats
+        Cat.all_cats_list = self.original_all_cats_list
+        Cat.ordered_cat_list = self.original_ordered_cat_list
+        Cat.outside_cats = self.original_outside_cats
+        names.prefix_history = self.original_prefix_history
+
+    def test_kit_names_reroll_prefixes_and_conflicting_full_names(self):
+        Cat(
+            prefix="Privet",
+            suffix="paw",
+            moons=6,
+            status_dict={"rank": CatRank.APPRENTICE},
+            disable_random=True,
+        )
+
+        Cat(prefix="Rain", suffix="fall", moons=20, disable_random=True)
+
+        new_kit = Cat(prefix="Privet", suffix="cloud", moons=0, disable_random=True)
+        new_kit.name = Name(prefix="Privet", suffix="cloud", cat=new_kit)
+
+        with patch(
+            "scripts.events_module.relationship.pregnancy_events.Name",
+            side_effect=[
+                Name(prefix="Rain", suffix="fall", cat=new_kit),
+                Name(prefix="Rain", suffix="flower", cat=new_kit),
+            ],
+        ) as patched_name:
+            patched_name.names_dict = Name.names_dict
+            Pregnancy_Events.ensure_unique_kit_name(new_kit, [])
+
+        self.assertEqual("Rain", new_kit.name.prefix)
+        self.assertEqual("flower", new_kit.name.suffix)
+        self.assertEqual(
+            patched_name.call_args_list,
+            [
+                call(
+                    biome=None,
+                    specsuffix_hidden=new_kit.specsuffix_hidden,
+                    cat=new_kit,
+                ),
+                call(
+                    prefix="Rain",
+                    biome=None,
+                    specsuffix_hidden=new_kit.specsuffix_hidden,
+                    cat=new_kit,
+                ),
+            ],
+        )


### PR DESCRIPTION
### Motivation
- Prevent duplicate kitten name prefixes and full-name collisions when generating kits, including conflicts with existing kittens and apprentices. 
- Make name rerolling respect clan biome and the kitten's `specsuffix_hidden` flag when creating `Name` objects. 

### Description
- Added `Pregnancy_Events.ensure_unique_kit_name(kit, litter_kittens, clan=None)` which re-rolls a kit's prefix and/or suffix until it does not conflict with prefixes in the same litter, apprentices/kittens in the clan, or any alive clan member full names, while respecting biome and `specsuffix_hidden` when constructing `Name` objects. 
- Replaced the old inline while-loop that prevented duplicate prefixes with a call to `ensure_unique_kit_name`. 
- Updated imports in `tests/test_relation_events.py` and added a new `KitNameConflicts` test case that sets up a minimal cat registry, patches `Name` to validate reroll behavior, and asserts the correct `Name` constructor calls and resulting prefix/suffix. 

### Testing
- Ran the modified relation events test file with `pytest tests/test_relation_events.py`, including `KitNameConflicts::test_kit_names_reroll_prefixes_and_conflicting_full_names`, and the test passed. 
- Existing tests in `tests/test_relation_events.py` were executed and remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb0045a820832ca483c97daf73e11b)