### PR TITLE
Normalize relationship interaction intensity and suppress spurious facet warnings

### DIFF
--- a/scripts/cat_relations/interaction.py
+++ b/scripts/cat_relations/interaction.py
@@ -27,7 +27,7 @@ class SingleInteraction:
         also_influences=None,
     ):
         self.id = interact_id
-        self.intensity = intensity
+        self.intensity = self._normalize_intensity(intensity)
         self.biome = biome if biome else ["any"]
         self.season = season if season else ["any"]
         self.interactions = (
@@ -61,6 +61,12 @@ class SingleInteraction:
         )
         self.reaction_random_cat = reaction_random_cat if reaction_random_cat else {}
         self.also_influences = also_influences if also_influences else {}
+
+    @staticmethod
+    def _normalize_intensity(intensity):
+        if intensity == "med":
+            return "medium"
+        return intensity
 
 
 class GroupInteraction:

--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -940,6 +940,7 @@ def gather_cat_objects(
             continue
 
         # FACET CATS IN CLAN
+        supported_facet_abbr = True
         if abbr == "high_social":
             found_cat_list = {c for c in out_set if c.personality.sociability > 8}
         elif abbr == "low_social":
@@ -956,6 +957,8 @@ def gather_cat_objects(
             found_cat_list = {c for c in out_set if c.personality.aggression > 8}
         elif abbr == "low_aggress":
             found_cat_list = {c for c in out_set if c.personality.aggression <= 8}
+        else:
+            supported_facet_abbr = False
 
         # add/remove cats if found and then continue for loop
         if is_exclusionary and found_cat_list:
@@ -967,7 +970,7 @@ def gather_cat_objects(
             out_set = found_cat_list
             continue
 
-        else:
+        if not supported_facet_abbr:
             print(f"WARNING: Unsupported abbreviation {abbr}")
 
     return list(out_set)

--- a/tests/test_consequences.py
+++ b/tests/test_consequences.py
@@ -1,0 +1,39 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from scripts.events_module.consequences import gather_cat_objects
+
+
+class TestGatherCatObjects(unittest.TestCase):
+    def setUp(self):
+        self.low_lawful_cat = SimpleNamespace(
+            status=SimpleNamespace(alive_in_player_clan=True),
+            personality=SimpleNamespace(
+                lawfulness=3, sociability=3, stability=3, aggression=3
+            ),
+        )
+        self.cat_class = SimpleNamespace(all_cats_list=[self.low_lawful_cat])
+        self.event = SimpleNamespace(
+            main_cat=None,
+            random_cat=None,
+            patrol_leader=None,
+            patrol_apprentices=[],
+            patrol_cats=[],
+            new_cats=[],
+        )
+
+    def test_supported_facet_abbreviation_with_no_matches_does_not_warn(self):
+        with patch("builtins.print") as mock_print:
+            gathered = gather_cat_objects(
+                self.cat_class, ["clan", "high_lawful"], self.event
+            )
+
+        self.assertEqual(gathered, [])
+        mock_print.assert_not_called()
+
+    def test_unknown_abbreviation_still_warns(self):
+        with patch("builtins.print") as mock_print:
+            gather_cat_objects(self.cat_class, ["clan", "unknown"], self.event)
+
+        mock_print.assert_called_once_with("WARNING: Unsupported abbreviation unknown")

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -17,6 +17,11 @@ from scripts.cat_relations.interaction import (
 
 
 class RelationshipConstraints(unittest.TestCase):
+    def test_single_interaction_normalizes_med_intensity(self):
+        interaction = SingleInteraction("test", intensity="med")
+
+        self.assertEqual(interaction.intensity, "medium")
+
     def test_siblings(self):
         # given
         parent = Cat()


### PR DESCRIPTION
### Motivation
- Fix recurring warnings: `"No interaction with this conditions."` caused by valid interactions being filtered out, and `"WARNING: Unsupported abbreviation high_lawful"` printed for valid facet abbreviations that simply matched no cats.
- Root causes: some interaction JSON entries used the legacy intensity label `med` while code expects `medium`, and facet filters treated any non-matching facet as an unknown abbreviation and always emitted a warning.

### Description
- Normalize interaction intensity by adding `_normalize_intensity` and using it in `SingleInteraction.__init__` so legacy `"med"` is treated as `"medium"` (`scripts/cat_relations/interaction.py`).
- Prevent spurious warnings in `gather_cat_objects` by tracking whether an abbreviation is a supported facet and only printing `WARNING: Unsupported abbreviation {abbr}` when truly unsupported (`scripts/events_module/consequences.py`).
- Add regression tests: update `tests/test_interactions.py` with `test_single_interaction_normalizes_med_intensity` and add `tests/test_consequences.py` to assert facet-abbreviation behavior and unknown-abbreviation warnings.

### Testing
- Compiled relevant modules successfully with `python -m compileall scripts/cat_relations/interaction.py scripts/events_module/consequences.py tests/test_interactions.py tests/test_consequences.py` and no syntax errors were reported.
- Performed targeted runtime/import checks that stubbed external deps, verifying `SingleInteraction` normalizes `"med"` to `"medium"` and `gather_cat_objects` now uses the supported-facet guard; both checks passed.
- Attempted to run `pytest tests/test_interactions.py tests/test_consequences.py -q`, but full test collection was blocked in this environment due to missing third-party packages (`strenum`, `i18n`), so end-to-end pytest run could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc8dbbdc00832c9ae04d05e6a30a19)