### PR TITLE
Add neutered/spayed permanent conditions and TNR (twoleg sterilization) handling

### DIFF
--- a/resources/dicts/conditions/permanent_conditions.json
+++ b/resources/dicts/conditions/permanent_conditions.json
@@ -12,10 +12,8 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
-        "risks": [
-        ],
+        "illness_infectiousness": [],
+        "risks": [],
         "herbs": {
             "1": [],
             "2": [],
@@ -35,8 +33,7 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
+        "illness_infectiousness": [],
         "risks": [
             {
                 "name": "an infected wound",
@@ -53,9 +50,9 @@
         ],
         "herbs": {
             "1": [
-            "marigold",
-            "ragwort"
-        ],
+                "marigold",
+                "ragwort"
+            ],
             "2": [
                 "daisy",
                 "juniper"
@@ -78,8 +75,7 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
+        "illness_infectiousness": [],
         "risks": [
             {
                 "name": "sore",
@@ -92,9 +88,9 @@
         ],
         "herbs": {
             "1": [
-            "marigold",
-            "ragwort"
-        ],
+                "marigold",
+                "ragwort"
+            ],
             "2": [
                 "daisy"
             ],
@@ -116,8 +112,7 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
+        "illness_infectiousness": [],
         "risks": [
             {
                 "name": "sore",
@@ -130,9 +125,9 @@
         ],
         "herbs": {
             "1": [
-            "marigold",
-            "ragwort"
-        ],
+                "marigold",
+                "ragwort"
+            ],
             "2": [
                 "daisy",
                 "juniper"
@@ -155,8 +150,7 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
+        "illness_infectiousness": [],
         "risks": [
             {
                 "name": "sore",
@@ -169,10 +163,10 @@
         ],
         "herbs": {
             "1": [
-            "marigold",
-            "ragwort",
-            "dandelion"
-        ],
+                "marigold",
+                "ragwort",
+                "dandelion"
+            ],
             "2": [
                 "juniper",
                 "daisy"
@@ -196,8 +190,7 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
+        "illness_infectiousness": [],
         "risks": [
             {
                 "name": "an infected wound",
@@ -210,8 +203,8 @@
         ],
         "herbs": {
             "1": [
-            "juniper"
-        ],
+                "juniper"
+            ],
             "2": [
                 "ragwort"
             ],
@@ -233,10 +226,8 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
-        "risks": [
-        ],
+        "illness_infectiousness": [],
+        "risks": [],
         "herbs": {
             "1": [],
             "2": [],
@@ -256,8 +247,7 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
+        "illness_infectiousness": [],
         "risks": [
             {
                 "name": "an infected wound",
@@ -278,11 +268,11 @@
         ],
         "herbs": {
             "1": [
-            "juniper",
-            "ragwort",
-            "marigold",
-            "dandelion"
-        ],
+                "juniper",
+                "ragwort",
+                "marigold",
+                "dandelion"
+            ],
             "2": [
                 "daisy",
                 "poppy"
@@ -305,8 +295,7 @@
             "senior adult": 60,
             "senior": 30
         },
-        "illness_infectiousness": [
-        ],
+        "illness_infectiousness": [],
         "risks": [
             {
                 "name": "whitecough",
@@ -315,8 +304,8 @@
         ],
         "herbs": {
             "1": [
-            "betony"
-        ],
+                "betony"
+            ],
             "2": [
                 "rosemary",
                 "juniper"
@@ -373,11 +362,11 @@
         ],
         "herbs": {
             "1": [
-            "juniper",
-            "ragwort",
-            "goldenrod",
-            "mullein"
-        ],
+                "juniper",
+                "ragwort",
+                "goldenrod",
+                "mullein"
+            ],
             "2": [
                 "betony",
                 "tansy"
@@ -401,7 +390,6 @@
             "senior": 75
         },
         "illness_infectiousness": [
-
             {
                 "name": "whitecough",
                 "chance": 10
@@ -431,11 +419,11 @@
         ],
         "herbs": {
             "1": [
-            "juniper",
-            "ragwort",
-            "goldenrod",
-            "dandelion"
-        ],
+                "juniper",
+                "ragwort",
+                "goldenrod",
+                "dandelion"
+            ],
             "2": [
                 "betony",
                 "mullein"
@@ -458,10 +446,8 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
-        "risks": [
-        ],
+        "illness_infectiousness": [],
+        "risks": [],
         "herbs": {
             "1": [],
             "2": [],
@@ -523,9 +509,9 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
-        "risks": [{
+        "illness_infectiousness": [],
+        "risks": [
+            {
                 "name": "failing eyesight",
                 "chance": 80
             }
@@ -549,8 +535,7 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
+        "illness_infectiousness": [],
         "risks": [
             {
                 "name": "blind",
@@ -576,8 +561,7 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
+        "illness_infectiousness": [],
         "risks": [
             {
                 "name": "deaf",
@@ -603,16 +587,13 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
-        "risks": [
-        ],
+        "illness_infectiousness": [],
+        "risks": [],
         "herbs": {
             "1": [],
             "2": [],
             "3": []
         }
-
     },
     "constant joint pain": {
         "severity": "minor",
@@ -627,8 +608,7 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
+        "illness_infectiousness": [],
         "risks": [
             {
                 "name": "joint pain",
@@ -637,8 +617,8 @@
         ],
         "herbs": {
             "1": [
-            "marigold"
-        ],
+                "marigold"
+            ],
             "2": [
                 "daisy",
                 "ragwort",
@@ -662,8 +642,7 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
+        "illness_infectiousness": [],
         "risks": [
             {
                 "name": "seizure",
@@ -672,15 +651,15 @@
         ],
         "herbs": {
             "1": [
-            "ragwort"
-        ],
+                "ragwort"
+            ],
             "2": [
                 "juniper"
-        ],
+            ],
             "3": [
                 "thyme",
                 "betony"
-        ]
+            ]
         }
     },
     "allergies": {
@@ -696,8 +675,7 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
+        "illness_infectiousness": [],
         "risks": [
             {
                 "name": "running nose",
@@ -725,8 +703,7 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
+        "illness_infectiousness": [],
         "risks": [
             {
                 "name": "headache",
@@ -752,8 +729,7 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
+        "illness_infectiousness": [],
         "risks": [
             {
                 "name": "constant nightmares",
@@ -766,8 +742,8 @@
         ],
         "herbs": {
             "1": [
-            "poppy"
-        ],
+                "poppy"
+            ],
             "2": [
                 "juniper"
             ],
@@ -789,8 +765,7 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
+        "illness_infectiousness": [],
         "risks": [
             {
                 "name": "grief stricken",
@@ -803,8 +778,8 @@
         ],
         "herbs": {
             "1": [
-            "poppy"
-        ],
+                "poppy"
+            ],
             "2": [
                 "juniper",
                 "ragwort"
@@ -827,8 +802,7 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
+        "illness_infectiousness": [],
         "risks": [
             {
                 "name": "severe headache",
@@ -841,13 +815,13 @@
         ],
         "herbs": {
             "1": [
-            "rosemary"
-        ],
+                "rosemary"
+            ],
             "2": [
                 "juniper"
             ],
             "3": [
-            "poppy"
+                "poppy"
             ]
         }
     },
@@ -864,15 +838,13 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
-        "risks": [
-        ],
+        "illness_infectiousness": [],
+        "risks": [],
         "herbs": {
             "1": [
-            "poppy",
-            "juniper"
-        ],
+                "poppy",
+                "juniper"
+            ],
             "2": [],
             "3": []
         }
@@ -890,8 +862,7 @@
             "senior adult": 0,
             "senior": 0
         },
-        "illness_infectiousness": [
-        ],
+        "illness_infectiousness": [],
         "risks": [
             {
                 "name": "sore throat",
@@ -900,9 +871,51 @@
         ],
         "herbs": {
             "1": [
-            "poppy",
-            "juniper"
-        ],
+                "poppy",
+                "juniper"
+            ],
+            "2": [],
+            "3": []
+        }
+    },
+    "neutered": {
+        "severity": "minor",
+        "congenital": "never",
+        "moons_until": 0,
+        "mortality": {
+            "newborn": 0,
+            "kitten": 0,
+            "adolescent": 0,
+            "young adult": 0,
+            "adult": 0,
+            "senior adult": 0,
+            "senior": 0
+        },
+        "illness_infectiousness": [],
+        "risks": [],
+        "herbs": {
+            "1": [],
+            "2": [],
+            "3": []
+        }
+    },
+    "spayed": {
+        "severity": "minor",
+        "congenital": "never",
+        "moons_until": 0,
+        "mortality": {
+            "newborn": 0,
+            "kitten": 0,
+            "adolescent": 0,
+            "young adult": 0,
+            "adult": 0,
+            "senior adult": 0,
+            "senior": 0
+        },
+        "illness_infectiousness": [],
+        "risks": [],
+        "herbs": {
+            "1": [],
             "2": [],
             "3": []
         }

--- a/resources/lang/en/hardcoded.en.json
+++ b/resources/lang/en/hardcoded.en.json
@@ -106,6 +106,9 @@
         },
         "event_returning_child_of_lost": "m_c approaches the Clan and asks to join, claiming to be %{parent_name}'s kitten.",
         "event_lost_mate": " To everyone's surprise, {PRONOUN/m_c/subject} {VERB/m_c/bring/brings} along a cat who m_c introduces as {PRONOUN/m_c/poss} mate.",
+        "event_tnr_return1": "m_c tells the tale of how {PRONOUN/m_c/subject} went to what kittypets called \"the cutter\" and how {PRONOUN/m_c/subject} just doesn't feel the same anymore.",
+        "event_tnr_return2": "Quietly, m_c explains that Twolegs brought {PRONOUN/m_c/object} to something kittypets call \"the cutter,\" and {PRONOUN/m_c/subject} still feels unsettled by it.",
+        "event_tnr_return3": "m_c admits that life among Twolegs changed {PRONOUN/m_c/object}; after a trip to \"the cutter,\" {PRONOUN/m_c/subject} says things have never felt quite the same.",
         "kittencough_spread": {
             "one": "Kittencough has spread around the nursery. %{kits} is affected.",
             "many": "Kittencough has spread around the nursery. %{kits} are affected."},

--- a/schemas/common.schema.json
+++ b/schemas/common.schema.json
@@ -429,9 +429,7 @@
         "constantly dizzy",
         "recurring shock",
         "lasting grief",
-        "persistent headaches",
-        "neutered",
-        "spayed"
+        "persistent headaches"
       ],
       "title": "PermCondition",
       "type": "string"

--- a/schemas/common.schema.json
+++ b/schemas/common.schema.json
@@ -429,7 +429,9 @@
         "constantly dizzy",
         "recurring shock",
         "lasting grief",
-        "persistent headaches"
+        "persistent headaches",
+        "neutered",
+        "spayed"
       ],
       "title": "PermCondition",
       "type": "string"

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -229,6 +229,8 @@ class Cat:
         self.no_kits = False
         self.no_mates = False
         self.no_retire = False
+        self.pending_neuter = False
+        self.tnr_victim = False
         self.skip_female_rarity_roll = kwargs.get("skip_female_rarity_roll", False)
 
         self.prevent_fading = False  # Prevents a cat from fading
@@ -1852,6 +1854,7 @@ class Cat:
         """Handles a moon skip for an alive cat."""
         old_age = self.age
         self.moons += 1
+        self.handle_pending_neuter()
         if self.moons == 1 and self.status.rank == CatRank.NEWBORN:
             self.status._change_rank(CatRank.KITTEN)
         self.in_camp = 1
@@ -2468,7 +2471,54 @@ class Cat:
                 "event_triggered": new_perm_condition.new,
             }
             new_condition = True
+            if new_perm_condition.name in ("neutered", "spayed"):
+                self.no_kits = True
         return new_condition
+
+    def get_sterilization_condition_name(self):
+        return "neutered" if self.gender == "male" else "spayed"
+
+    def apply_sterilization_condition(
+        self, from_twolegs: bool = False, adjust_personality: bool = False
+    ) -> bool:
+        """
+        Applies a permanent sterilization condition to this cat.
+        Returns True if a new condition was applied.
+        """
+        if self.age.is_baby():
+            return False
+
+        sterilization_condition = self.get_sterilization_condition_name()
+        was_added = self.get_permanent_condition(sterilization_condition)
+        if not was_added:
+            return False
+
+        self.no_kits = True
+        if "partial hearing loss" in self.permanent_condition:
+            self.permanent_condition.pop("partial hearing loss", None)
+
+        if (
+            ("RIGHTEAR" not in self.pelt.scars)
+            and (self.status.alive_in_player_clan or self.status.social == CatSocial.LONER)
+        ):
+            self.pelt.scars = (*self.pelt.scars, "RIGHTEAR")
+
+        if adjust_personality:
+            self.personality.aggression = self.personality.aggression - 2
+            self.personality.stability = self.personality.stability + 2
+
+        if from_twolegs:
+            self.tnr_victim = True
+
+        return True
+
+    def handle_pending_neuter(self):
+        if not self.pending_neuter:
+            return
+
+        self.pending_neuter = False
+        if random_module.getrandbits(1):
+            self.apply_sterilization_condition(from_twolegs=True, adjust_personality=True)
 
     def not_working(self):
         """returns True if the cat cannot work, False if the cat can work"""
@@ -3693,6 +3743,8 @@ class Cat:
                 "no_kits": self.no_kits,
                 "no_retire": self.no_retire,
                 "no_mates": self.no_mates,
+                "pending_neuter": self.pending_neuter,
+                "tnr_victim": self.tnr_victim,
                 "pelt_name": self.pelt.name,
                 "pelt_color": self.pelt.colour,
                 "pelt_length": self.pelt.length,

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -2238,12 +2238,17 @@ def handle_injuries_or_general_death(cat):
 
         return True
 
+    sterilized = any(cond in cat.permanent_condition for cond in ("neutered", "spayed"))
+    max_old_age = 324 if sterilized else 300
+
     # chance to die of old age
     age_start = constants.CONFIG["death_related"]["old_age_death_start"]
     death_curve_setting = constants.CONFIG["death_related"]["old_age_death_curve"]
     death_curve_value = 0.001 * death_curve_setting
     # made old_age_death_chance into a separate value to make testing with print statements easier
     old_age_death_chance = ((1 + death_curve_value) ** (cat.moons - age_start)) - 1
+    if sterilized:
+        old_age_death_chance *= 0.7
     if random.random() <= old_age_death_chance:
         create_short_event(
             event_type="birth_death",
@@ -2251,8 +2256,8 @@ def handle_injuries_or_general_death(cat):
             sub_type=["old_age"],
         )
         return True
-    # max age has been indicated to be 300, so if a cat reaches that age, they die of old age
-    elif cat.moons >= 300:
+    # max age has been indicated to be 300, but sterilized cats can live a bit longer
+    elif cat.moons >= max_old_age:
         create_short_event(
             event_type="birth_death",
             main_cat=cat,

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -972,6 +972,32 @@ def handle_lost_cats_return(predetermined_cat_IDs: list = None):
                 # stop after first valid reunion
                 break
 
+    for cat_ID in cat_IDs:
+        returned_cat = Cat.fetch_cat(cat_ID)
+        if (
+            returned_cat
+            and returned_cat.status.alive_in_player_clan
+            and returned_cat.tnr_victim
+            and returned_cat.status.is_former_clancat
+        ):
+            sterilized_condition = returned_cat.get_sterilization_condition_name()
+            if (
+                sterilized_condition in returned_cat.permanent_condition
+                and "RIGHTEAR" not in returned_cat.pelt.scars
+            ):
+                returned_cat.pelt.scars = (*returned_cat.pelt.scars, "RIGHTEAR")
+                returned_cat.permanent_condition.pop("partial hearing loss", None)
+            returned_cat.tnr_victim = False
+            tale_text = event_text_adjust(
+                Cat,
+                i18n.t(f"hardcoded.event_tnr_return{random.choice(range(1,4))}"),
+                main_cat=returned_cat,
+                clan=game.clan,
+            )
+            game.cur_events_list.append(
+                Single_Event(tale_text, ["misc", "health"], [returned_cat.ID])
+            )
+
     # Perform a ceremony if needed
     for cat_ID in cat_IDs:
         x = Cat.fetch_cat(cat_ID)

--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -830,6 +830,13 @@ def create_new_cat(
                     chosen_condition = ("partial hearing loss")
                     new_cat.get_permanent_condition(chosen_condition, born_with=True)
 
+        if (
+            original_social in (CatSocial.KITTYPET, CatSocial.LONER)
+            and not new_cat.age.is_baby()
+            and bool(getrandbits(1))
+        ):
+            new_cat.apply_sterilization_condition()
+
 
         # KILL >:D only if we're sposed to tho
         if not alive:

--- a/scripts/events_module/outsider_events.py
+++ b/scripts/events_module/outsider_events.py
@@ -80,6 +80,10 @@ class OutsiderEvents:
                 death_curve_setting = constants.CONFIG["death_related"]["old_age_death_curve"]
                 death_curve_value = 0.001 * death_curve_setting
                 old_age_death_chance = ((1 + death_curve_value) ** (cat.moons - age_start)) - 1
+                sterilized = any(cond in cat.permanent_condition for cond in ("neutered", "spayed"))
+                if sterilized:
+                    old_age_death_chance *= 0.7
+                max_old_age = 324 if sterilized else 300
 
                 social = i18n.t(f"general.{cat.status.social}", count=1)
 
@@ -90,7 +94,7 @@ class OutsiderEvents:
                     )
                     death_history = "m_c died of old age."
 
-                elif cat.moons >= 300:
+                elif cat.moons >= max_old_age:
                     text = (
                         f"Rumors reach your Clan that the {social}, "
                         f"{cat.name}, has died recently."

--- a/scripts/events_module/patrol/patrol_outcome.py
+++ b/scripts/events_module/patrol/patrol_outcome.py
@@ -588,11 +588,25 @@ class PatrolOutcome:
 
         [_cat.become_lost() for _cat in cats_to_lose]
 
+        patrol_id = patrol.patrol_event.patrol_id if patrol.patrol_event else ""
+        twoleg_abduction_patrol = self._is_twoleg_abduction_loss_patrol(patrol_id)
+        if twoleg_abduction_patrol:
+            for _cat in cats_to_lose:
+                _cat.pending_neuter = True
+
         return i18n.t(
             "screens.patrol.lost_cats",
             count=len(cats_to_lose),
             cats=adjust_list_text([str(cat.name) for cat in cats_to_lose]),
         )
+
+    @staticmethod
+    def _is_twoleg_abduction_loss_patrol(patrol_id: str) -> bool:
+        if patrol_id in {"gen_hunt_gonetnr1", "gen_hunt_gonetnr2"}:
+            return True
+
+        patrol_id_lower = patrol_id.lower()
+        return "twoleg" in patrol_id_lower or "tnr" in patrol_id_lower
 
     def _handle_condition_and_scars(self, patrol: "Patrol") -> str:
         """Handle injuring cats, or giving scars"""

--- a/scripts/events_module/short/short_event.py
+++ b/scripts/events_module/short/short_event.py
@@ -646,9 +646,12 @@ class ShortEvent:
                 )  # got to include the cat that rolled for death in the first place
 
             taken_cats = []
+            twoleg_abduction_event = "twoleg" in self.event_id.lower() or "twoleg" in self.text.lower()
             for kitty in self.dead_cat_objects:
                 if "lost" in self.tags:
                     kitty.become_lost()
+                    if twoleg_abduction_event:
+                        kitty.pending_neuter = True
                     taken_cats.append(kitty)
                 self.multi_cat_objects.append(kitty)
                 if kitty.ID not in self.all_involved_cat_ids:

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -225,6 +225,16 @@ def json_load():
             new_cat.no_kits = cat["no_kits"]
             new_cat.no_mates = cat["no_mates"] if "no_mates" in cat else False
             new_cat.no_retire = cat["no_retire"] if "no_retire" in cat else False
+            new_cat.pending_neuter = (
+                cat["pending_neuter"]
+                if "pending_neuter" in cat
+                else cat.get("pending_twoleg_sterilization", False)
+            )
+            new_cat.tnr_victim = (
+                cat["tnr_victim"]
+                if "tnr_victim" in cat
+                else cat.get("twoleg_sterilization_story_pending", False)
+            )
 
             if "skill_dict" in cat:
                 new_cat.skills = CatSkills(cat["skill_dict"])

--- a/scripts/models/common/perm_condition.py
+++ b/scripts/models/common/perm_condition.py
@@ -24,3 +24,5 @@ class PermCondition(Enum):
     recurring_shock = "recurring shock"
     lasting_grief = "lasting grief"
     persistent_headaches = "persistent headaches"
+    neutered = "neutered"
+    spayed = "spayed"


### PR DESCRIPTION
### Motivation
- Represent sterilization (neuter/spay) as permanent conditions and model Twoleg/TNR interactions that can sterilize cats during abductions or returns.
- Ensure sterilization impacts reproduction and appearance (e.g. `no_kits` and RIGHTEAR scar) and that the state is persisted and handled across events and loading.

### Description
- Add `neutered` and `spayed` to the `PermCondition` enum, `common.schema.json`, and `resources/dicts/conditions/permanent_conditions.json`, and tidy up several JSON arrays for consistency.
- Add `pending_neuter` and `tnr_victim` flags to `Cat`, plus `get_sterilization_condition_name`, `apply_sterilization_condition`, and `handle_pending_neuter`, and call `handle_pending_neuter` from `one_moon`; applying sterilization sets `no_kits`, may add the `RIGHTEAR` scar, remove `partial hearing loss`, and can adjust personality.
- Mark lost cats from twoleg/TNR abduction patrols and short events with `pending_neuter`, randomly apply sterilization to certain newly created kittypet/loner cats during creation, and append a return-story event when TNR victims come back in `events.handle_lost_cats_return`.
- Add backward-compatible loading of `pending_neuter` and `tnr_victim` in `load_cat.json_load` and new localized strings `event_tnr_return1-3` in `resources/lang/en/hardcoded.en.json`.

### Testing
- Ran the project's unit test suite and JSON schema validation, and the tests completed successfully.
- Ran linter/static checks with no errors reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6e762eb34832c827222581b800461)