### PR TITLE
Fix spayed/neutered moons placeholder rendering in profile condition details

### DIFF
--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -1905,14 +1905,20 @@ class ProfileScreen(Screens):
                         game.clan.age - self.the_cat.permanent_condition[name]["moon_start"]
                     )
                     text_list.append(
-                        i18n.t("general.has_been_spayed_for", count=moons_with)
+                        i18n.t(
+                            "general.has_been_spayed_for",
+                            moons=i18n.t("general.moons_age", count=moons_with),
+                        )
                     )
                 elif name == "neutered":
                     moons_with = (
                         game.clan.age - self.the_cat.permanent_condition[name]["moon_start"]
                     )
                     text_list.append(
-                        i18n.t("general.has_been_neutered_for", count=moons_with)
+                        i18n.t(
+                            "general.has_been_neutered_for",
+                            moons=i18n.t("general.moons_age", count=moons_with),
+                        )
                     )
                 else:
                     moons_with = (


### PR DESCRIPTION
### Motivation
- Fix a UI bug where sterilization detail text showed an unresolved `%{moons}` placeholder because the translation expected a `moons` interpolation value rather than a raw `count`.

### Description
- In `scripts/screens/ProfileScreen.py` inside `get_condition_details`, pass `moons=i18n.t("general.moons_age", count=moons_with)` to `general.has_been_spayed_for` and `general.has_been_neutered_for` instead of using `count=moons_with`, aligning these cases with other condition formatting.

### Testing
- Compiled the modified file with `python -m compileall /workspace/clangen/scripts/screens/ProfileScreen.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c70fb50be0832ca4eb0dde030b9cf7)