### PR TITLE
Add TNR ear-clip scar history and skip RIGHTEAR for generated kittypets

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2504,7 +2504,7 @@ class Cat:
             self.pelt.scars = (*self.pelt.scars, "RIGHTEAR")
             if from_twolegs:
                 self.history.add_scar(
-                    "m_c got their ear clipped after {PRONOUN/m_c/subject} was abducted by twolegs and taken to the cutter"
+                    "m_c got {PRONOUN/m_c/poss} ear clipped after {PRONOUN/m_c/subject} was trapped by Twolegs, fixed, and released back into the wild."
                 )
 
         if adjust_personality:

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2502,6 +2502,10 @@ class Cat:
             and (self.status.alive_in_player_clan or self.status.social == CatSocial.LONER)
         ):
             self.pelt.scars = (*self.pelt.scars, "RIGHTEAR")
+            if from_twolegs:
+                self.history.add_scar(
+                    "m_c got their ear clipped after {PRONOUN/m_c/subject} was abducted by twolegs and taken to the cutter"
+                )
 
         if adjust_personality:
             self.personality.aggression = self.personality.aggression - 2

--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -837,6 +837,10 @@ def create_new_cat(
         ):
             was_sterilized = new_cat.apply_sterilization_condition()
             if was_sterilized:
+                if original_social == CatSocial.KITTYPET:
+                    new_cat.pelt.scars = tuple(
+                        scar for scar in new_cat.pelt.scars if scar != "RIGHTEAR"
+                    )
                 new_cat.backdate_sterilization_history(original_social)
 
 


### PR DESCRIPTION
### Motivation
- Record explicit scar history when a cat receives the `RIGHTEAR` ear-clip from Twoleg sterilization so the event is reflected in the cat's history.
- Avoid showing a visible `RIGHTEAR` scar on cats that were randomly generated as kittypets while preserving their sterilization condition and backdated history.

### Description
- When `apply_sterilization_condition(..., from_twolegs=True)` adds `RIGHTEAR`, also call `history.add_scar(...)` with the text: `m_c got their ear clipped after {PRONOUN/m_c/subject} was abducted by twolegs and taken to the cutter` in `scripts/cat/cats.py`.
- During new-cat generation in `scripts/events_module/consequences.py`, if a generated cat is sterilized and `original_social == CatSocial.KITTYPET`, remove `RIGHTEAR` from `new_cat.pelt.scars` while still calling `backdate_sterilization_history(original_social)`.
- Changes affect `scripts/cat/cats.py` and `scripts/events_module/consequences.py` and preserve existing sterilization and TNR flagging behavior.

### Testing
- Compiled the modified modules with `python -m compileall /workspace/clangen/scripts/cat/cats.py /workspace/clangen/scripts/events_module/consequences.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c713560418832cabc7f64251f3b353)