### PR TITLE
Fix unbound `inverse_chance` in adoption kit chance calculation

### DIFF
--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -1565,8 +1565,9 @@ class Pregnancy_Events:
         # Now that the second parent is determined, we can calculate the balanced chance for kits
         # get the chance for pregnancy
         if kits_are_adopted:
-            if len(first_parent.mate) > 0 and not affair:
-                inverse_chance = constants.CONFIG["pregnancy"]["primary_chance_same_sex_adoption"]
+            inverse_chance = constants.CONFIG["pregnancy"][
+                "primary_chance_same_sex_adoption"
+            ]
         else:
             inverse_chance = constants.CONFIG["pregnancy"]["primary_chance_unmated"]
             if len(first_parent.mate) > 0 and not affair:


### PR DESCRIPTION
### Motivation
- Prevent an `UnboundLocalError` in `get_balanced_kit_chance` when `kits_are_adopted` is true by ensuring the `inverse_chance` baseline is always initialized.

### Description
- When `kits_are_adopted` is true, always set `inverse_chance` to `constants.CONFIG["pregnancy"]["primary_chance_same_sex_adoption"]` so later modifiers can safely operate on it without relying on conditional branches.

### Testing
- Ran `python -m py_compile scripts/events_module/relationship/pregnancy_events.py`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c716e8e018832cae2ee1cf62671c10)