### PR TITLE
Prevent sterilized cats from being assigned as parents

### DIFF
--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -22,6 +22,21 @@ from scripts.cat.constants import BACKSTORIES, PERMANENT
 from scripts.events_module.text_adjust import process_text, adjust_list_text
 
 
+def ensure_parent_is_not_sterilized(cat: Optional["Cat"]) -> None:
+    """Remove sterilization conditions from a cat that has been assigned as a parent."""
+    if not cat:
+        return
+
+    removed_condition = False
+    for condition in ("spayed", "neutered"):
+        if condition in cat.permanent_condition:
+            cat.permanent_condition.pop(condition, None)
+            removed_condition = True
+
+    if removed_condition:
+        cat.no_kits = False
+
+
 def create_new_cat_block(
     Cat: Optional["Cat"],
     Relationship,
@@ -389,6 +404,10 @@ def create_new_cat_block(
 
     # Now we generate the new cat
     if not chosen_cat:
+        if litter or rank in (CatRank.KITTEN, CatRank.NEWBORN):
+            for par in (parent1, parent2):
+                ensure_parent_is_not_sterilized(par)
+
         new_cats = create_new_cat(
             Cat,
             new_name=new_name,

--- a/tests/test_consequences.py
+++ b/tests/test_consequences.py
@@ -2,7 +2,10 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from scripts.events_module.consequences import gather_cat_objects
+from scripts.events_module.consequences import (
+    gather_cat_objects,
+    ensure_parent_is_not_sterilized,
+)
 
 
 class TestGatherCatObjects(unittest.TestCase):
@@ -37,3 +40,25 @@ class TestGatherCatObjects(unittest.TestCase):
             gather_cat_objects(self.cat_class, ["clan", "unknown"], self.event)
 
         mock_print.assert_called_once_with("WARNING: Unsupported abbreviation unknown")
+
+
+class TestEnsureParentIsNotSterilized(unittest.TestCase):
+    def test_removes_sterilization_flags_from_parent(self):
+        parent = SimpleNamespace(
+            permanent_condition={"spayed": {"severity": "minor"}, "blind": {}},
+            no_kits=True,
+        )
+
+        ensure_parent_is_not_sterilized(parent)
+
+        self.assertNotIn("spayed", parent.permanent_condition)
+        self.assertIn("blind", parent.permanent_condition)
+        self.assertFalse(parent.no_kits)
+
+    def test_no_changes_when_parent_not_sterilized(self):
+        parent = SimpleNamespace(permanent_condition={"blind": {}}, no_kits=True)
+
+        ensure_parent_is_not_sterilized(parent)
+
+        self.assertEqual({"blind": {}}, parent.permanent_condition)
+        self.assertTrue(parent.no_kits)


### PR DESCRIPTION
### Motivation
- Fix a bug where cats spawned as parents for kits/litters could still have `spayed`/`neutered` permanent conditions and `no_kits` set, producing contradictory states (e.g., a she-cat listed as both a parent with kits and `spayed`).

### Description
- Added `ensure_parent_is_not_sterilized(cat: Optional["Cat"])` in `scripts/events_module/consequences.py` to remove `spayed`/`neutered` from `cat.permanent_condition` and clear `cat.no_kits` when a cat is assigned as a biological parent.
- Call the helper prior to generating newborns/kittens or litters in `create_new_cat_block` when `litter` is True or `rank` is `KITTEN`/`NEWBORN` so parents are sanitized before new cats are created.
- Added unit tests in `tests/test_consequences.py` for `ensure_parent_is_not_sterilized` that verify removal of sterilization flags and correct handling when no sterilization is present.

### Testing
- Ran `pytest -q tests/test_consequences.py` in this environment which attempted to collect the tests but failed during collection due to a missing runtime dependency (`ModuleNotFoundError: No module named 'i18n'`).
- The new unit tests were added and are present in `tests/test_consequences.py`, but test execution could not complete here because of the missing `i18n` module during import of `scripts/events_module/consequences.py`.
- No other automated tests were run in this environment; the changes are limited to `scripts/events_module/consequences.py` and `tests/test_consequences.py`.}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c71aa48ac8832cb439576f0acc4bf6)