### PR TITLE
Weight outsider sterilization backdating toward earlier spay/neuter for kittypets and loners

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2537,11 +2537,18 @@ class Cat:
             return
 
         # AVMA recommendation is by 5 months for non-breeding cats.
+        # Use weighted ranges so older outsiders are more likely to have been
+        # sterilized for most of their life instead of only recently.
         if social_group == CatSocial.KITTYPET:
-            fix_age = randint(5, self.moons - 1)
+            latest_typical_fix = min(self.moons - 1, max(6, int(self.moons * 0.45)))
+            fix_age = int(random_module.triangular(5, latest_typical_fix, 7))
         elif social_group == CatSocial.LONER:
-            min_age = min(self.moons - 1, max(10, int(self.moons * 0.5)))
-            fix_age = randint(min_age, self.moons - 1)
+            earliest_fix = min(self.moons - 1, max(8, int(self.moons * 0.2)))
+            latest_typical_fix = min(self.moons - 1, max(earliest_fix, int(self.moons * 0.6)))
+            mode_fix = min(latest_typical_fix, max(earliest_fix, int(self.moons * 0.35)))
+            fix_age = int(
+                random_module.triangular(earliest_fix, latest_typical_fix, mode_fix)
+            )
         else:
             fix_age = randint(5, self.moons - 1)
 


### PR DESCRIPTION
### Motivation
- Outsider cats (kittypets and loners) generated with sterilization backdating could end up appearing to have been sterilized very recently even if they are very old, which is unintuitive for e.g. a 131-moon kittypet that should plausibly have been spayed for most of its life. 

### Description
- Changed `backdate_sterilization_history` in `scripts/cat/cats.py` to use weighted (triangular) sampling for `fix_age` when `social_group` is `KITTYPET` so kittypets skew toward earlier sterilization ages. 
- Added a weighted triangular sampling strategy for `LONER` with an earlier and later bound plus a mode so loners still trend later than kittypets but are more likely to have been sterilized for a substantial portion of life. 
- Left other groups using the previous uniform `randint` fallback and preserved the existing minimum-age guard (`self.moons <= 5`).

### Testing
- Compiled the modified module with `python -m compileall scripts/cat/cats.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c71e1c3fb4832c887b2c28ddf199d4)