### PR TITLE
Backdate sterilization with weighted timing and reduce loner sterilization frequency

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2543,12 +2543,8 @@ class Cat:
             latest_typical_fix = min(self.moons - 1, max(6, int(self.moons * 0.45)))
             fix_age = int(random_module.triangular(5, latest_typical_fix, 7))
         elif social_group == CatSocial.LONER:
-            earliest_fix = min(self.moons - 1, max(8, int(self.moons * 0.2)))
-            latest_typical_fix = min(self.moons - 1, max(earliest_fix, int(self.moons * 0.6)))
-            mode_fix = min(latest_typical_fix, max(earliest_fix, int(self.moons * 0.35)))
-            fix_age = int(
-                random_module.triangular(earliest_fix, latest_typical_fix, mode_fix)
-            )
+            min_age = min(self.moons - 1, max(10, int(self.moons * 0.5)))
+            fix_age = randint(min_age, self.moons - 1)
         else:
             fix_age = randint(5, self.moons - 1)
 

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2537,11 +2537,18 @@ class Cat:
             return
 
         # AVMA recommendation is by 5 months for non-breeding cats.
+        # Use weighted ranges so older outsiders are more likely to have been
+        # sterilized for most of their life instead of only recently.
         if social_group == CatSocial.KITTYPET:
-            fix_age = randint(5, self.moons - 1)
+            latest_typical_fix = min(self.moons - 1, max(6, int(self.moons * 0.45)))
+            fix_age = int(random_module.triangular(5, latest_typical_fix, 7))
         elif social_group == CatSocial.LONER:
-            min_age = min(self.moons - 1, max(10, int(self.moons * 0.5)))
-            fix_age = randint(min_age, self.moons - 1)
+            earliest_fix = min(self.moons - 1, max(8, int(self.moons * 0.2)))
+            latest_typical_fix = min(self.moons - 1, max(earliest_fix, int(self.moons * 0.6)))
+            mode_fix = min(latest_typical_fix, max(earliest_fix, int(self.moons * 0.35)))
+            fix_age = int(
+                random_module.triangular(earliest_fix, latest_typical_fix, mode_fix)
+            )
         else:
             fix_age = randint(5, self.moons - 1)
 

--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -849,11 +849,14 @@ def create_new_cat(
                     chosen_condition = ("partial hearing loss")
                     new_cat.get_permanent_condition(chosen_condition, born_with=True)
 
-        if (
-            original_social in (CatSocial.KITTYPET, CatSocial.LONER)
-            and not new_cat.age.is_baby()
-            and bool(getrandbits(1))
-        ):
+        should_apply_sterilization = False
+        if original_social in (CatSocial.KITTYPET, CatSocial.LONER) and not new_cat.age.is_baby():
+            if original_social == CatSocial.LONER:
+                should_apply_sterilization = randint(1, 5) == 1
+            else:
+                should_apply_sterilization = bool(getrandbits(1))
+
+        if should_apply_sterilization:
             was_sterilized = new_cat.apply_sterilization_condition()
             if was_sterilized:
                 if original_social == CatSocial.KITTYPET:


### PR DESCRIPTION
### Motivation

- Make sterilization history more realistic by biasing older outsiders toward having been sterilized earlier in life.
- Reduce the odds that loner cats are sterilized at generation time to better reflect typical population differences.
- Preserve existing scar handling and ensure sterilization history is backdated when the condition is applied.

### Description

- Replaced uniform `randint` backdating in `Cat.backdate_sterilization_history` with weighted `random_module.triangular` ranges and computed `earliest_fix`, `latest_typical_fix`, and `mode_fix` for `KITTYPET` and `LONER` to bias older cats toward earlier sterilization. 
- Changed sterilization decision in `create_new_cat` (`scripts/events_module/consequences.py`) to compute `should_apply_sterilization` where `LONER` cats are sterilized only on a 1-in-5 chance via `randint(1, 5)` while `KITTYPET` retains a `getrandbits(1)` coin flip. 
- Kept existing post-sterilization behavior: apply condition, remove `RIGHTEAR` scar for kitties, and call `backdate_sterilization_history` when sterilization is applied.

### Testing

- Ran the project's unit test suite with `pytest` and all tests passed. 
- Executed a cat-generation smoke test that triggers the new sterilization branches and verified no exceptions and expected `moon_start` adjustments. 
- Ran automated lint/type checks and they completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c71e1c3fb4832c887b2c28ddf199d4)