### PR TITLE
Include negative effect postscript for affair relationship logs in pregnancy events

### DIFF
--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -779,6 +779,7 @@ class Pregnancy_Events:
                                 "r_c": (str(cat.name), choice(cat.pronouns)),
                             },
                         )
+                        + i18n.t("relationships.negative_postscript")
                         + i18n.t(
                             "relationships.age_postscript",
                             name=str(cat.name),
@@ -807,6 +808,7 @@ class Pregnancy_Events:
                                 "r_c": (str(other_cat.name), choice(other_cat.pronouns)),
                             },
                         )
+                        + i18n.t("relationships.negative_postscript")
                         + i18n.t(
                             "relationships.age_postscript",
                             name=str(other_cat.name),


### PR DESCRIPTION
### Motivation
- Ensure affair-related relationship log entries include the same negative-effect marker used by romantic interactions so logs show the `(negative effect)` postscript consistently.

### Description
- Added `i18n.t("relationships.negative_postscript")` to the affair penalty log entries in `scripts/events_module/relationship/pregnancy_events.py` for both the cat's mates and `other_cat`'s mates, inserted before the age postscript.

### Testing
- Ran `pytest -q tests/test_romantic_events.py`, but test collection failed due to a missing dependency: `ModuleNotFoundError: No module named 'i18n'`, so automated tests could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c81d842a64832c82faaf23ae23e77d)