### PR TITLE
Reduce romance interactions for mixed sterilization pairs

### DIFF
--- a/scripts/cat_relations/relationship.py
+++ b/scripts/cat_relations/relationship.py
@@ -442,6 +442,12 @@ class Relationship:
             while RelType.ROMANCE in value_weights:
                 value_weights.pop(RelType.ROMANCE)
 
+        if (
+            RelType.ROMANCE in value_weights
+            and self._is_sterilized_intact_pair()
+        ):
+            value_weights[RelType.ROMANCE] *= 0.35
+
         # if cats have no romance relationship already, don't allow romance decrease
         if (
             not positive
@@ -455,6 +461,15 @@ class Relationship:
             [weight for weight in value_weights.values()],
         )[0]
         return chosen_type
+
+    @staticmethod
+    def _is_sterilized(cat) -> bool:
+        return any(cond in cat.permanent_condition for cond in ("neutered", "spayed"))
+
+    def _is_sterilized_intact_pair(self) -> bool:
+        cat_from_sterilized = self._is_sterilized(self.cat_from)
+        cat_to_sterilized = self._is_sterilized(self.cat_to)
+        return cat_from_sterilized != cat_to_sterilized
 
     def get_relevant_interactions(
         self,

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from unittest.mock import patch
 
 from scripts.cat_relations.enums import rel_type_tiers, RelType
 
@@ -518,3 +519,30 @@ class SingleInteractionCatConstraints(unittest.TestCase):
         self.assertTrue(
             cats_fulfill_single_interaction_constraints(clan, clan, all_to_clan)
         )
+
+
+class RomanceInteractionWeighting(unittest.TestCase):
+    @patch("scripts.cat_relations.relationship.random.choices")
+    def test_mixed_sterilization_pair_reduces_romance_weight(self, mocked_choices):
+        cat_from = Cat(age="adult", moons=30, disable_random=True)
+        cat_to = Cat(age="adult", moons=30, disable_random=True)
+        cat_from.permanent_condition["neutered"] = {}
+        mixed_relationship = Relationship(cat_from, cat_to)
+
+        mocked_choices.return_value = [RelType.LIKE]
+        mixed_relationship.get_interaction_type(positive=True)
+        mixed_values = mocked_choices.call_args.args[0]
+        mixed_weights = mocked_choices.call_args.args[1]
+        mixed_romance_weight = mixed_weights[mixed_values.index(RelType.ROMANCE)]
+
+        intact_cat_from = Cat(age="adult", moons=30, disable_random=True)
+        intact_cat_to = Cat(age="adult", moons=30, disable_random=True)
+        intact_relationship = Relationship(intact_cat_from, intact_cat_to)
+
+        mocked_choices.return_value = [RelType.LIKE]
+        intact_relationship.get_interaction_type(positive=True)
+        intact_values = mocked_choices.call_args.args[0]
+        intact_weights = mocked_choices.call_args.args[1]
+        intact_romance_weight = intact_weights[intact_values.index(RelType.ROMANCE)]
+
+        self.assertLess(mixed_romance_weight, intact_romance_weight)


### PR DESCRIPTION
### Motivation
- Make romantic interactions less likely when one cat is sterilized (`spayed`/`neutered`) and the other is intact so mixed sterilization-status pairs reflect reduced mating likelihood while keeping romance possible.

### Description
- Lower the romance interaction selection weight inside `Relationship.get_interaction_type` by multiplying `RelType.ROMANCE` weight by `0.35` for mixed sterilized/intact pairs in `scripts/cat_relations/relationship.py`.
- Add `Relationship._is_sterilized` and `Relationship._is_sterilized_intact_pair` helper methods to encapsulate sterilization checks and keep logic reusable.
- Add a unit test `RomanceInteractionWeighting.test_mixed_sterilization_pair_reduces_romance_weight` in `tests/test_interactions.py` that mocks `random.choices` to assert the romance weight is lower for a mixed sterilization pair vs an intact/intact pair, and add the required `patch` import.

### Testing
- `python -m py_compile scripts/cat_relations/relationship.py tests/test_interactions.py` completed successfully.
- Attempted `pytest -q tests/test_interactions.py -k mixed_sterilization_pair_reduces_romance_weight`, which could not run in this environment due to a missing dependency (`strenum`) during test collection (test code is in place but the environment lacks `strenum`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caf4076e78832c8fd4021dc9b4a76e)