### PR TITLE
Make patrol new-cat names clickable to open profiles (with back navigation)

### DIFF
--- a/scripts/events_module/patrol/patrol_outcome.py
+++ b/scripts/events_module/patrol/patrol_outcome.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: ascii -*-
+from html import escape
 import random
 from os.path import exists as path_exists
 from random import choice, choices
@@ -47,6 +48,11 @@ class PatrolOutcome:
         Personality.trait_ranges["kit_traits"].keys()
     )
     NUM_OF_SKILLS = len(SkillPath)
+
+    @staticmethod
+    def _profile_link(cat: Cat) -> str:
+        """Create a UI hyperlink to a cat profile."""
+        return f'<a href="cat://{cat.ID}">{escape(str(cat.name))}</a>'
 
     def __init__(
         self,
@@ -907,7 +913,7 @@ class PatrolOutcome:
                 elif cat.status.is_outsider or cat.status.is_other_clancat:
                     outside.append(str(cat.name))
                 else:
-                    new.append(str(cat.name))
+                    new.append(self._profile_link(cat))
             for type_list, string in [
                 (dead, "screens.patrol.dead_outsider"),
                 (outside, "screens.patrol.met_outsider"),

--- a/scripts/screens/PatrolScreen.py
+++ b/scripts/screens/PatrolScreen.py
@@ -18,6 +18,7 @@ from .Screens import Screens
 from .enums import GameScreen
 from ..clan_package.settings import get_clan_setting
 from ..game_structure import image_cache, constants
+from ..game_structure.game.switches import switch_set_value, Switch
 from ..game_structure.game.settings import game_setting_get
 from ..cat.enums import CatRank
 from ..game_structure.propagating_thread import PropagatingThread
@@ -74,6 +75,14 @@ class PatrolScreen(Screens):
         if event.type == pygame_gui.UI_BUTTON_DOUBLE_CLICKED:
             if self.patrol_stage == "choose_cats":
                 self.handle_choose_cats_events(event)
+        elif event.type == pygame_gui.UI_TEXT_BOX_LINK_CLICKED:
+            if event.link_target.startswith("cat://"):
+                cat_id = event.link_target.split("cat://", maxsplit=1)[1]
+                cat = Cat.fetch_cat(cat_id)
+                if isinstance(cat, Cat):
+                    switch_set_value(Switch.cat, cat.ID)
+                    game.last_screen_forProfile = GameScreen.PATROL
+                    self.change_screen(GameScreen.PROFILE)
 
         elif event.type == pygame_gui.UI_BUTTON_START_PRESS:
             if self.patrol_stage == "choose_cats":


### PR DESCRIPTION
### Motivation
- Allow players to open a newly-joined cat's profile directly from the patrol results text and return to the same patrol when they press the profile back button. 

### Description
- Render newly joined in-clan cat names in patrol outcomes as internal profile hyperlinks (`<a href="cat://<id>">Name</a>`) by adding a `_profile_link` helper and escaping display names in `scripts/events_module/patrol/patrol_outcome.py`.
- Handle text-box link clicks in `PatrolScreen.handle_event` to open the target cat profile when a `cat://` link is clicked by calling `switch_set_value(Switch.cat, cat.ID)` and switching to `GameScreen.PROFILE` in `scripts/screens/PatrolScreen.py`.
- Ensure profile back navigation returns to the patrol by setting `game.last_screen_forProfile = GameScreen.PATROL` before changing screens.
- Added required import of `switch_set_value`/`Switch` in `PatrolScreen` and `escape` from `html` in `patrol_outcome`.

### Testing
- Compiled the modified files with `python -m compileall scripts/events_module/patrol/patrol_outcome.py scripts/screens/PatrolScreen.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caf4522b74832c95888cc4244193d3)