### PR TITLE
Fix crash when a cat has null experience in save data

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -3629,6 +3629,11 @@ class Cat:
 
     @experience.setter
     def experience(self, exp: int):
+        # Old or externally edited saves may contain a null experience value.
+        # Treat that as 0 so loading doesn't crash.
+        if exp is None:
+            exp = 0
+
         exp = min(exp, self.experience_levels_range["master"][1])
         self._experience = int(exp)
 


### PR DESCRIPTION
### Motivation
- Loading older or externally edited saves could set a cat's experience to `None`, causing `TypeError` in the `Cat.experience` setter when comparing with integers, so loading should tolerate null experience values.

### Description
- Add a `None` guard in the `Cat.experience` setter in `scripts/cat/cats.py` that treats `None` as `0` before applying the `min(...)` cap and casting to `int`, preventing the comparison error.

### Testing
- Ran `python -m compileall scripts/cat/cats.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbf8932378832c8443d25b448aae18)