### PR TITLE
Fix missing TNR return text in outsider lost-cat return events

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -580,7 +580,9 @@ def handle_lead_den_event():
 
             # this handles ceremonies for cats coming into the clan
             if invited_cats:
-                handle_lost_cats_return(invited_cats)
+                tnr_return_text = handle_lost_cats_return(invited_cats)
+                if tnr_return_text:
+                    event_text += f" {tnr_return_text}"
 
         # give new thought to cats
         if "new_thought" in cat_dict:
@@ -866,6 +868,7 @@ def handle_lost_cats_return(predetermined_cat_IDs: list = None):
     TODO: DOCS
     """
     cat_IDs = []
+    tnr_return_texts = []
     if predetermined_cat_IDs:
         cat_IDs = predetermined_cat_IDs
 
@@ -877,11 +880,11 @@ def handle_lost_cats_return(predetermined_cat_IDs: list = None):
         ]
 
         if not eligible_cats:
-            return
+            return ""
 
         lost_cat = random.choice(eligible_cats)
         if lost_cat.age in (CatAge.NEWBORN, CatAge.KITTEN):
-            return
+            return ""
 
         cat_IDs.append(lost_cat.ID)
 
@@ -994,9 +997,12 @@ def handle_lost_cats_return(predetermined_cat_IDs: list = None):
                 main_cat=returned_cat,
                 clan=game.clan,
             )
-            game.cur_events_list.append(
-                Single_Event(tale_text, ["misc", "health"], [returned_cat.ID])
-            )
+            if predetermined_cat_IDs:
+                tnr_return_texts.append(tale_text)
+            else:
+                game.cur_events_list.append(
+                    Single_Event(tale_text, ["misc", "health"], [returned_cat.ID])
+                )
 
     # Perform a ceremony if needed
     for cat_ID in cat_IDs:
@@ -1017,6 +1023,8 @@ def handle_lost_cats_return(predetermined_cat_IDs: list = None):
                     ceremony(x, CatRank.WARRIOR)
             elif not x.status.rank.is_any_apprentice_rank() and x.moons >= 6:
                 ceremony(x, CatRank.APPRENTICE)
+
+    return " ".join(tnr_return_texts)
 
 
 def handle_fading(cat):


### PR DESCRIPTION
### Motivation
- Leader-den/outsider return events that pass a predetermined cat list were not displaying the Two-N-Return (TNR) flavor text alongside the outsider narrative, causing the sterilization-return message to be omitted from the same event.
- The goal is to ensure TNR return flavor text is visible in the same outsider event message rather than being lost or posted separately.

### Description
- Updated `handle_lost_cats_return` to collect TNR return snippets into `tnr_return_texts` when called with `predetermined_cat_IDs` and return a joined string of those snippets instead of always creating separate `Single_Event` entries. 
- Changed early-return behavior to return an empty string (`""`) in the predetermined-call path so the function always returns a string in that mode. 
- In the caller (outsider/leader-den flow), capture the return value of `handle_lost_cats_return(invited_cats)` and append it to the outsider `event_text` when present. 
- Modified file: `scripts/events.py` and preserved the original separate-event behavior for the non-predetermined (random monthly) flow.

### Testing
- Ran `python -m compileall scripts/events.py` and the file compiled successfully. 
- No additional automated unit tests were available or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1b91ff938832ca9ba34a40e213384)