### PR TITLE
Aggregate herb quantities in focus, add skill/status filters to events

### DIFF
--- a/resources/lang/en/events/death/general.json
+++ b/resources/lang/en/events/death/general.json
@@ -1121,6 +1121,9 @@
       "status": [
         "any"
       ],
+      "skill": [
+        "-SWIMMER,2"
+      ],
       "dies": true
     },
     "r_c": {
@@ -1131,6 +1134,9 @@
       ],
       "status": [
         "any"
+      ],
+      "skill": [
+        "-SWIMMER,2"
       ],
       "trait": [
         "bold",

--- a/resources/lang/en/events/misc/general.json
+++ b/resources/lang/en/events/misc/general.json
@@ -11803,6 +11803,12 @@
                 "senior adult",
                 "senior"
             ],
+            "status": [
+                "apprentice",
+                "warrior",
+                "deputy",
+                "leader"
+            ],
             "skill": [
                 "HEALER,1"
             ]
@@ -11912,7 +11918,8 @@
             {
                 "type": "freshkill",
                 "trigger": [
-                    "low"
+                    "low",
+                    "adequate"
                 ],
                 "adjust": "increase_20"
             }

--- a/scripts/clan_resources/herb/herb_supply.py
+++ b/scripts/clan_resources/herb/herb_supply.py
@@ -384,26 +384,30 @@ class HerbSupply:
         """
 
         # get herbs found
-        herb_list = []
+        gathered_herbs = defaultdict(int)
         for med in med_cats:
             if assistants:
-                list_of_herb_strs, found_herbs = game.clan.herb_supply.get_found_herbs(
+                _, found_herbs = game.clan.herb_supply.get_found_herbs(
                     med,
                     general_amount_bonus=True,
                     specific_quantity_bonus=2,
                 )
             else:
-                list_of_herb_strs, found_herbs = game.clan.herb_supply.get_found_herbs(
-                    med
-                )
-            herb_list.extend(found_herbs)
+                _, found_herbs = game.clan.herb_supply.get_found_herbs(med)
+            for herb, amount in found_herbs.items():
+                gathered_herbs[herb] += amount
 
-        # remove dupes
-        herb_list = list(set(herb_list))
-        # get display strings for herbs
+        # get display strings for herbs with quantity
         herb_strs = []
-        for herb in herb_list:
-            herb_strs.append(game.clan.herb_supply.herb[herb].plural_display)
+        for herb, amount in gathered_herbs.items():
+            if amount == 1:
+                herb_strs.append(
+                    f"{amount} {game.clan.herb_supply.herb[herb].singular_display}"
+                )
+            else:
+                herb_strs.append(
+                    f"{amount} {game.clan.herb_supply.herb[herb].plural_display}"
+                )
 
         herb_list = adjust_list_text(herb_strs)
 


### PR DESCRIPTION
### Motivation

- Ensure herb gathering reflects quantities found (not just unique names) and displays singular/plural counts.  
- Prevent inappropriate cats from appearing in specific scripted events by tightening swim-skill filters for drownings and status filters for medicine-cat helpers.  
- Make supply-trigger conditions for the healer herb-gather event more permissive by including `adequate` alongside `low`.

### Description

- Update `HerbSupply.handle_focus` to aggregate herbs using a `defaultdict(int)`, sum counts returned by `get_found_herbs`, and build quantity-aware display strings using `singular_display`/`plural_display`.  
- Adjust the local unpacking of `get_found_herbs` results to ignore the unused return and iterate the `found_herbs` dict to accumulate amounts.  
- Change `gen_med_healer_herb_gather` event to add `m_c.status` requirement of `apprentice`, `warrior`, `deputy`, or `leader` and to add `adequate` to the `supplies` `trigger` for `freshkill`.  
- Update `gen_death_drown_any1` event entries to include a `skill` filter `"-SWIMMER,2"` for both `m_c` and `r_c`, adding a SWIMMER-skill based filter to the drowning scenario.

### Testing

- Ran the herb supply unit tests that cover `handle_focus` behavior and display generation and they passed.  
- Ran the event parsing/validation tests to ensure the modified event JSON entries are accepted and they passed.  
- Ran linters/type checks on the changed Python file and there were no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d343d4e0ac832cb3dbc3d1daabccd1)