### PR TITLE
Handle pending neuter for returned cats and relax TNR return condition

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -977,11 +977,14 @@ def handle_lost_cats_return(predetermined_cat_IDs: list = None):
 
     for cat_ID in cat_IDs:
         returned_cat = Cat.fetch_cat(cat_ID)
+        if returned_cat and returned_cat.pending_neuter:
+            # Mirror the normal moon-skip flow so Twoleg-abducted cats resolve
+            # their pending sterilization state before we build return text.
+            returned_cat.handle_pending_neuter()
         if (
             returned_cat
             and returned_cat.status.alive_in_player_clan
             and returned_cat.tnr_victim
-            and returned_cat.status.is_former_clancat
         ):
             sterilized_condition = returned_cat.get_sterilization_condition_name()
             if (


### PR DESCRIPTION
### Motivation
- Ensure cats that were abducted and have a pending sterilization resolve their pending state when they return so the return text and status reflect the sterilization outcome.
- Allow TNR return handling to run for returned cats that meet the TNR victim criteria without requiring them to be flagged as former clan members.

### Description
- Call `returned_cat.handle_pending_neuter()` for any returned cat with `pending_neuter` before assembling return event text so sterilization is applied consistently. 
- Remove the `returned_cat.status.is_former_clancat` requirement from the TNR return condition so TNR processing runs for eligible returned cats that are alive in the player clan and marked as `tnr_victim`.
- Preserve existing TNR post-processing which adds a `RIGHTEAR` scar, clears the `partial hearing loss` permanent condition, sets `tnr_victim = False`, and emits the appropriate return event via `Single_Event`.

### Testing
- Ran the project's automated test suite using `pytest`, and all tests passed. 
- Executed the event-handling smoke tests for lost/returned cats, and the updated TNR and pending-neuter flows behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d35c8dece8832c9c12bfbb150bd149)