### PR TITLE
Fix UnboundLocalError in _describe_torties by initializing base

### DIFF
--- a/scripts/cat/pelts.py
+++ b/scripts/cat/pelts.py
@@ -1345,6 +1345,7 @@ def _describe_torties(cat, color_name, short=False) -> (str, str):
             base_color = ""
     else:
         base_color = str(color_name).replace("cat.pelts.", "").lower()
+    base = cat.pelt.tortie_base.lower()
 
     # Short description: just the pelt type
     if short:
@@ -1354,7 +1355,6 @@ def _describe_torties(cat, color_name, short=False) -> (str, str):
         ):
             color_name = "mottled"
         else:
-            base = cat.pelt.tortie_base.lower()
             if base in [tabby.lower() for tabby in Pelt.tabbies] + ["bengal", "rosette", "speckled"]:
                 # torbie/tabico for tabby bases
                 if cat.pelt.name.lower() == "tortie":


### PR DESCRIPTION
### Motivation
- Prevent a crash when describing tortie pelts where the local variable `base` could be referenced before being set, causing an `UnboundLocalError` in `_describe_torties`.

### Description
- Initialize `base` with `cat.pelt.tortie_base.lower()` near the top of `_describe_torties` and remove the now-redundant inner assignment, updating `scripts/cat/pelts.py` so both short and long description paths can safely reference `base`.

### Testing
- Ran `python -m compileall scripts/cat/pelts.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95972fa18832c8f52de4c3d93a02d)