### PR TITLE
Add oldest lineage moon stat to Clan Settings

### DIFF
--- a/resources/lang/en/screens/clan_settings.en.json
+++ b/resources/lang/en/screens/clan_settings.en.json
@@ -9,6 +9,6 @@
         "role": "role settings",
         "role_info": "Change Clan-specific settings regarding cat roles",
         "stats": "clan stats",
-        "stats_text": "Living Clan Cats: %{living}\nStarClan Cats: %{starclan}\nDark Forest Cats: %{darkforest}\nUnknown Residence Cats: %{unknownresidence}\nOutside Cats: %{catsoutside}\nMedicine Cats: %{medcats}\nMedicine Cat Apprentices: %{medcatapps}\nWarriors: %{warriors}\nWarrior Apprentices: %{apps}\nMediators: %{mediators}\nMediator Apprentices: %{mediatorapps}\nElders: %{elders}\nKittens and Newborns: %{kits}\nFaded Cats: %{faded}\nGender Ratio: %{male} males : %{female} females\nAverage Age of the Clan: %{avg_age} moons\nMated Pairs: %{mated_pairs}"
+        "stats_text": "Living Clan Cats: %{living}\nStarClan Cats: %{starclan}\nDark Forest Cats: %{darkforest}\nUnknown Residence Cats: %{unknownresidence}\nOutside Cats: %{catsoutside}\nMedicine Cats: %{medcats}\nMedicine Cat Apprentices: %{medcatapps}\nWarriors: %{warriors}\nWarrior Apprentices: %{apps}\nMediators: %{mediators}\nMediator Apprentices: %{mediatorapps}\nElders: %{elders}\nKittens and Newborns: %{kits}\nFaded Cats: %{faded}\nGender Ratio: %{male} males : %{female} females\nAverage Age of the Clan: %{avg_age} moons\nMated Pairs: %{mated_pairs}\nOldest Generation: Dates back %{oldest_generation} moons"
     }
 }

--- a/scripts/screens/ClanSettingsScreen.py
+++ b/scripts/screens/ClanSettingsScreen.py
@@ -308,6 +308,7 @@ class ClanSettingsScreen(Screens):
         female = 0
         avg_age = 0
         mated_pair_count = 0
+        oldest_generation_moons = 0
         for cat in Cat.all_cats_list:
             if cat.faded:
                 faded_cats += 1
@@ -372,6 +373,10 @@ class ClanSettingsScreen(Screens):
                     mated_pairs.add(pair)
 
             mated_pair_count = len(mated_pairs)
+
+            oldest_generation_moons = max(
+                oldest_generation_moons, self._get_lineage_depth_in_moons(cat)
+            )
         
         self.checkboxes_text["stat_box"] = pygame_gui.elements.UITextBox(
             "screens.clan_settings.stats_text",
@@ -396,8 +401,36 @@ class ClanSettingsScreen(Screens):
                 "catsoutside": str(cats_outside),
                 "avg_age": str(avg_age),
                 "mated_pairs": str(mated_pair_count),
+                "oldest_generation": str(oldest_generation_moons),
             },
         )
+
+    def _get_lineage_depth_in_moons(self, cat: Cat) -> int:
+        """Return how many moons this cat's oldest known bloodline stretches back."""
+        return self._get_oldest_ancestor_moons(cat, set())
+
+    def _get_oldest_ancestor_moons(self, cat: Cat, path_ids: set[str]) -> int:
+        """Recursively find the highest moon total across known blood ancestors."""
+        if not cat or cat.ID in path_ids:
+            return 0
+
+        next_path_ids = set(path_ids)
+        next_path_ids.add(cat.ID)
+
+        parent_ids = [cat.parent1, cat.parent2]
+        oldest_ancestor_moons = 0
+
+        for parent_id in parent_ids:
+            parent_cat = Cat.fetch_cat(parent_id)
+            if not parent_cat:
+                continue
+
+            oldest_ancestor_moons = max(
+                oldest_ancestor_moons,
+                self._get_oldest_ancestor_moons(parent_cat, next_path_ids),
+            )
+
+        return cat.moons + oldest_ancestor_moons
 
     def refresh_checkboxes(self):
         """


### PR DESCRIPTION
### Motivation
- Provide a clan-level stat that reports how far back the oldest bloodline in the clan dates (in moons) so players can see the deepest/earliest lineage in the clan.

### Description
- Added an `oldest_generation_moons` metric in `ClanSettingsScreen.open_clan_stats` and expose it as `oldest_generation` to the stats text kwargs in `scripts/screens/ClanSettingsScreen.py`.
- Implemented recursive helpers `_get_lineage_depth_in_moons` and `_get_oldest_ancestor_moons` that traverse `parent1`/`parent2`, call `Cat.fetch_cat(...)` to include faded ancestors when available, and use a visited-ID set to avoid cycles.
- Updated English localization `resources/lang/en/screens/clan_settings.en.json` to include the new line `Oldest Generation: Dates back %{oldest_generation} moons`.

### Testing
- Successfully compiled the modified module with `python -m py_compile scripts/screens/ClanSettingsScreen.py` (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da7677a370832c85fa0dd0675f71c5)