### PR TITLE
Fix missing age initialization for faded cats

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -394,11 +394,11 @@ class Cat:
         self.mate = []
         self.status = Status(**status) if status else Status()
         self._pronouns = {}  # Needs to be set as a dict
+        self.age: Optional[CatAge] = None
+        self.init_moons_age(moons)
         self.moons = moons
         self.inheritance = None  # This should never be used, but just for safety
         self.name = Name(prefix=prefix, suffix=suffix, cat=self)
-
-        self.init_moons_age(moons)
 
         self.set_faded()  # Sets the faded sprite and faded tag (self.faded = True)
         return True


### PR DESCRIPTION
### Motivation
- Prevent the runtime error `ERROR: cat has no age attribute! Cat ID: x` (which could freeze clan stats) by ensuring faded cats have their `age` computed before the `moons` property setter runs.

### Description
- In `init_faded()` initialize `self.age` and call `init_moons_age(moons)` before assigning `self.moons`, and explicitly declare `self.age: Optional[CatAge] = None` so the `moons` setter never observes an undefined `age` during faded-cat loading.

### Testing
- Compiled the modified module with `python -m compileall scripts/cat/cats.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa39407ec832c892eef53acd9c6ca)