### PR TITLE
Only include pregnancy co-parent IDs when text references r_c

### DIFF
--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -49,6 +49,15 @@ class Pregnancy_Events:
     currently_loaded_lang: str = None
 
     @staticmethod
+    def append_second_parent_if_mentioned(
+        involved_cats: List[str], event_template: str, mentioned_cat: Optional[Cat]
+    ) -> List[str]:
+        """Append the second parent/mate ID only if the event text references `r_c`."""
+        if mentioned_cat and "r_c" in event_template and mentioned_cat.ID not in involved_cats:
+            involved_cats.append(mentioned_cat.ID)
+        return involved_cats
+
+    @staticmethod
     def rebuild_strings():
         if Pregnancy_Events.currently_loaded_lang == i18n.config.get("locale"):
             return
@@ -356,22 +365,29 @@ class Pregnancy_Events:
             # so their ID is appended to the event
             if allow_affair is False:
                 text = choice(Pregnancy_Events.PREGNANT_STRINGS["announcement"])
+                event_template = text
                 severity = random.choices(["minor", "major"], [3, 1], k=1)
                 pregnant_cat.get_injured("pregnant", severity=severity[0])
                 text += choice(Pregnancy_Events.PREGNANT_STRINGS[f"{severity[0]}_severity"])
                 text = event_text_adjust(Cat, text, main_cat=pregnant_cat, random_cat=other_cat, clan=game.clan)
                 involved_cats = [pregnant_cat.ID]
-                involved_cats.append(second_parent.ID)
+                involved_cats = Pregnancy_Events.append_second_parent_if_mentioned(
+                    involved_cats, event_template, other_cat
+                )
             # If affairs ARE allowed, take away the second parents's ID so the player 
             # can have some fun guessing whether it's a secret affair or not 
             # (if the second parent isn't already mentioned in the event)
             elif allow_affair is True and second_parent.ID in pregnant_cat.mate: 
                 text = choice(Pregnancy_Events.PREGNANT_STRINGS["announcement"])
+                event_template = text
                 severity = random.choices(["minor", "major"], [3, 1], k=1)
                 pregnant_cat.get_injured("pregnant", severity=severity[0])
                 text += choice(Pregnancy_Events.PREGNANT_STRINGS[f"{severity[0]}_severity"])
                 text = event_text_adjust(Cat, text, main_cat=pregnant_cat, random_cat=other_cat, clan=game.clan)
                 involved_cats = [pregnant_cat.ID]
+                involved_cats = Pregnancy_Events.append_second_parent_if_mentioned(
+                    involved_cats, event_template, other_cat
+                )
             # If the pregnant cat is single and had a fling with a random cat, let them announce their surpise pregnancy 
             # and leave the Clan and the player pointing fingers on who the second parent may be
             elif allow_coparenting is True and len(pregnant_cat.mate) == 0:
@@ -385,11 +401,16 @@ class Pregnancy_Events:
             # let the player guess whether it's an affair or not, sometimes the events will tell you, sometimes they won't...
             elif allow_affair is True and second_parent.ID not in pregnant_cat.mate and len(pregnant_cat.mate) > 0:
                 text = choice(Pregnancy_Events.PREGNANT_STRINGS["announcement_affair"])
+                event_template = text
                 severity = random.choices(["minor", "major"], [3, 1], k=1)
                 pregnant_cat.get_injured("pregnant", severity=severity[0])
                 text += choice(Pregnancy_Events.PREGNANT_STRINGS[f"{severity[0]}_severity"])
-                text = event_text_adjust(Cat, text, main_cat=pregnant_cat, random_cat=male_mate[0] if male_mate else None, clan=clan)
+                event_random_cat = male_mate[0] if male_mate else None
+                text = event_text_adjust(Cat, text, main_cat=pregnant_cat, random_cat=event_random_cat, clan=clan)
                 involved_cats = [pregnant_cat.ID]
+                involved_cats = Pregnancy_Events.append_second_parent_if_mentioned(
+                    involved_cats, event_template, event_random_cat
+                )
             game.cur_events_list.append(Single_Event(text, "birth_death", involved_cats))
         else:
             if not other_cat and cat.gender == "male":
@@ -447,20 +468,27 @@ class Pregnancy_Events:
             # if affairs aren't allowed, it's ok for the player to know who the daddy is, so his ID is appended to the event
             if allow_affair is False:
                 text = choice(Pregnancy_Events.PREGNANT_STRINGS["announcement"])
+                event_template = text
                 severity = random.choices(["minor", "major"], [3, 1], k=1)
                 pregnant_cat.get_injured("pregnant", severity=severity[0])
                 text += choice(Pregnancy_Events.PREGNANT_STRINGS[f"{severity[0]}_severity"])
                 text = event_text_adjust(Cat, text, main_cat=pregnant_cat, random_cat=other_cat, clan=game.clan)
                 involved_cats = [pregnant_cat.ID]
-                involved_cats.append(second_parent.ID)
+                involved_cats = Pregnancy_Events.append_second_parent_if_mentioned(
+                    involved_cats, event_template, other_cat
+                )
             # If affairs ARE allowed, take away the daddy's ID so the player can have some fun guessing wether it's an affair or not (if the father isn't mentioned in the event)
             elif allow_affair is True and second_parent.ID in pregnant_cat.mate: 
                 text = choice(Pregnancy_Events.PREGNANT_STRINGS["announcement"])
+                event_template = text
                 severity = random.choices(["minor", "major"], [3, 1], k=1)
                 pregnant_cat.get_injured("pregnant", severity=severity[0])
                 text += choice(Pregnancy_Events.PREGNANT_STRINGS[f"{severity[0]}_severity"])
                 text = event_text_adjust(Cat, text, main_cat=pregnant_cat, random_cat=other_cat, clan=game.clan)
                 involved_cats = [pregnant_cat.ID]
+                involved_cats = Pregnancy_Events.append_second_parent_if_mentioned(
+                    involved_cats, event_template, other_cat
+                )
             # If the mom is single and had a fling with a random tom cat, let her announce her pregnancy and leave the Clan and the player pointing fingers on who the daddy may be
             elif allow_coparenting is True and len(pregnant_cat.mate) == 0:
                 text = choice(Pregnancy_Events.PREGNANT_STRINGS["surprising_announcement"])
@@ -472,19 +500,29 @@ class Pregnancy_Events:
             # If the mother is in a relationship with another she-cat and she gets knocked-up by a tom, let there be some drama for that!
             elif allow_affair is True and second_parent.ID not in pregnant_cat.mate and has_female_mate:
                 text = choice(Pregnancy_Events.PREGNANT_STRINGS["announcement_affair_samesex"])
+                event_template = text
                 severity = random.choices(["minor", "major"], [3, 1], k=1)
                 pregnant_cat.get_injured("pregnant", severity=severity[0])
                 text += choice(Pregnancy_Events.PREGNANT_STRINGS[f"{severity[0]}_severity"])
-                text = event_text_adjust(Cat, text, main_cat=pregnant_cat, random_cat=female_mate[0] if female_mate else None, clan=clan)
+                event_random_cat = female_mate[0] if female_mate else None
+                text = event_text_adjust(Cat, text, main_cat=pregnant_cat, random_cat=event_random_cat, clan=clan)
                 involved_cats = [pregnant_cat.ID]
+                involved_cats = Pregnancy_Events.append_second_parent_if_mentioned(
+                    involved_cats, event_template, event_random_cat
+                )
             # And lastly, if the mom got knocked up by another tom who ISN'T her mate, let the player guess whether it's an affair or not, sometimes the events will tell you, sometimes they won't...
             elif allow_affair is True and second_parent.ID not in pregnant_cat.mate and has_male_mate:
                 text = choice(Pregnancy_Events.PREGNANT_STRINGS["announcement_affair"])
+                event_template = text
                 severity = random.choices(["minor", "major"], [3, 1], k=1)
                 pregnant_cat.get_injured("pregnant", severity=severity[0])
                 text += choice(Pregnancy_Events.PREGNANT_STRINGS[f"{severity[0]}_severity"])
-                text = event_text_adjust(Cat, text, main_cat=pregnant_cat, random_cat=male_mate[0] if male_mate else None, clan=clan)
+                event_random_cat = male_mate[0] if male_mate else None
+                text = event_text_adjust(Cat, text, main_cat=pregnant_cat, random_cat=event_random_cat, clan=clan)
                 involved_cats = [pregnant_cat.ID]
+                involved_cats = Pregnancy_Events.append_second_parent_if_mentioned(
+                    involved_cats, event_template, event_random_cat
+                )
             game.cur_events_list.append(Single_Event(text, "birth_death", involved_cats))
 
     @staticmethod


### PR DESCRIPTION
### Motivation
- Prevent appending the second parent/mate ID to pregnancy announcement events unless the chosen event template actually mentions the second-parent placeholder `r_c`, and ensure affair/announcement_affair flows follow the same rule.

### Description
- Add a helper `append_second_parent_if_mentioned(involved_cats, event_template, mentioned_cat)` that appends the mentioned cat's ID only when `event_template` contains `r_c`.
- Capture the raw selected event template in `event_template` before calling `event_text_adjust` and use it to decide whether to attach the second parent ID.
- Replace direct `involved_cats.append(second_parent.ID)` calls across the zero-moon pregnancy announcement branches (normal and same-sex flows, affair variants) with the new helper.
- Use `event_random_cat` temporaries when passing a random mate to `event_text_adjust` so the helper can be called consistently with the correct `mentioned_cat` object.

### Testing
- Compiled the modified module with `python -m py_compile scripts/events_module/relationship/pregnancy_events.py`, and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dea8a3b078832c9d00cfd154c71bc4)