### PR TITLE
Use insert-style mate placeholders in pregnancy birth events

### DIFF
--- a/resources/lang/en/conditions/pregnancy.json
+++ b/resources/lang/en/conditions/pregnancy.json
@@ -150,25 +150,25 @@
             "m_c hopes that {PRONOUN/m_c/poss} {insert} doesn't look too much like r_c, otherwise questions might follow.",
             "r_c goes to visit m_c in the nursery with {PRONOUN/m_c/poss} new {insert}, on a completely innocent mission to deliver food to the new parent.",
             "The newly arrived {insert} that m_c has just given birth to looks suspiciously like r_c. ",
-			"Everyone in the Clan can see that m_c's {insert} clearly looks like r_c... r_c's mate has been glaring at {PRONOUN/r_c/object} and m_c ever since the {insert} have been born.",
-			"r_c's mate has been demanding answers from {PRONOUN/r_c/object} ever since m_c's {insert} was born — The {insert} looks way too much like him! Why in the name of StarClan did r_c cheat on them with another cat!?",
+			"Everyone in the Clan can see that m_c's {insert} clearly looks like r_c... {rc_mate} has been glaring at {PRONOUN/r_c/object} and m_c ever since the {insert} have been born.",
+			"{rc_mate} has been demanding answers from {PRONOUN/r_c/object} ever since m_c's {insert} was born — The {insert} looks way too much like him! Why in the name of StarClan did r_c cheat on them with another cat!?",
             "No one wants to ruin such a happy occasion, but... it doesn't take a genius to notice how m_c's {insert} looks suspiciously like r_c...",
             "Ever since the birth, rumor's gone around that m_c's {insert} belongs to r_c and, while no one wants to confirm anything, no one really has to when the evidence is mewling right there...",
 			"r_c adamantly denies that m_c's newly born {insert} belongs to {PRONOUN/r_c/object} when questioned, but it's hard to believe {PRONOUN/r_c/object} when they're so similar..."
         ],
         "affair_mated": [
-            "m_c's mate is such a wonderful cat, deserving of being a parent... so why does m_c's {insert} look more like r_c instead?",
-			"Everyone in the Clan can see that m_c's {insert} clearly looks like r_c... m_c's mate has been glaring at {PRONOUN/m_c/object} and r_c ever since the {insert} have been born.",
-			"m_c's mate has been demanding answers from {PRONOUN/m_c/object} ever since the {insert} was born — The {insert} looks way too much like r_c! Why in the name of StarClan would m_c cheat on {PRONOUN/m_m/object} with another cat!? Is {PRONOUN/m_m/subject} not worthy of fathering {PRONOUN/m_c/poss} kits!?",
-            "m_c can see it, m_c's mate can see it, r_c can see it, everyone in c_n can see how the new {insert} looks a bit too much like r_c for it to be coincidence..."
+            "{mc_mate} is such a wonderful cat, deserving of being a parent... so why does m_c's {insert} look more like r_c instead?",
+			"Everyone in the Clan can see that m_c's {insert} clearly looks like r_c... {mc_mate} has been glaring at {PRONOUN/m_c/object} and r_c ever since the {insert} have been born.",
+			"{mc_mate} has been demanding answers from {PRONOUN/m_c/object} ever since the {insert} was born — The {insert} looks way too much like r_c! Why in the name of StarClan would m_c cheat on {PRONOUN/mc_mate/object} with another cat!? Is {PRONOUN/mc_mate/subject} not worthy of fathering {PRONOUN/m_c/poss} kits!?",
+            "m_c can see it, {mc_mate} can see it, r_c can see it, everyone in c_n can see how the new {insert} looks a bit too much like r_c for it to be coincidence..."
         ],
         "affair_mated_samesex": [
-			"m_c gave birth to a {insert}, made from her and r_c. m_c's mate will help raise them as well — The perfect opportunity for the same-sex pair to become parents for once.",
-            "m_c's mate looks over m_c's new {insert} with mixed feelings — on one hand, m_c did cheat on her with r_c... but at the same time, she can help m_c raise this {insert} together since they could never have kits of their own! Seems like r_c did them a favor there."
+			"m_c gave birth to a {insert}, made from her and r_c. {mc_mate} will help raise them as well — The perfect opportunity for the same-sex pair to become parents for once.",
+            "{mc_mate} looks over m_c's new {insert} with mixed feelings — on one hand, m_c did cheat on her with r_c... but at the same time, she can help m_c raise this {insert} together since they could never have kits of their own! Seems like r_c did them a favor there."
         ],
         "affair_mated_dead_mate": [
-            "m_c's mate was such a wonderful cat, deserving of being a parent, even after death... so why does m_c's {insert} look more like r_c instead?",
-            "This was supposed to be a bittersweet moment — m_c birthing her new {insert}, a last gift from m_c's mate. Except, this {insert} isn't m_c's mate's at all... they're r_c's."
+            "{mc_mate} was such a wonderful cat, deserving of being a parent, even after death... so why does m_c's {insert} look more like r_c instead?",
+            "This was supposed to be a bittersweet moment — m_c birthing her new {insert}, a last gift from {mc_mate}. Except, this {insert} isn't {mc_mate}'s at all... they're r_c's."
         ],
         "death": [
             "Later, as the medicine cat wails with m_c's blood streaked through their pelt and a warrior comes to move the body for the vigil, no one knows what to do with the {insert}.",

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -689,7 +689,7 @@ class Pregnancy_Events:
             cat_dict["r_c"] = other_cat
             chosen_mate = Pregnancy_Events.get_first_mate(cat)
             if chosen_mate:
-                cat_dict["m_m"] = chosen_mate
+                cat_dict["mc_mate"] = chosen_mate
                 involved_cats.append(chosen_mate.ID)
             event_list.append(choice(events["birth"]["affair_mated_samesex"]))
         # affair birth event where the birthing cat had an affair
@@ -699,12 +699,12 @@ class Pregnancy_Events:
             involved_cats.append(other_cat.ID)
             cat_dict["r_c"] = other_cat
             if living_mate:
-                cat_dict["m_m"] = living_mate
+                cat_dict["mc_mate"] = living_mate
                 involved_cats.append(living_mate.ID)
                 event_list.append(choice(events["birth"]["affair_mated"]))
             # including the dead mate version because of a bug where the game can't find any birthing events if the original mate is dead
             elif dead_mate:
-                cat_dict["m_m"] = dead_mate
+                cat_dict["mc_mate"] = dead_mate
                 involved_cats.append(dead_mate.ID)
                 event_list.append(choice(events["birth"]["affair_mated_dead_mate"]))
         # affair birth event if the birthing cat had kits with a mated cat
@@ -713,16 +713,11 @@ class Pregnancy_Events:
             if other_mate:
                 involved_cats.append(other_cat.ID)
                 cat_dict["r_c"] = other_cat
-                cat_dict["r_m"] = other_mate
+                cat_dict["rc_mate"] = other_mate
                 involved_cats.append(other_mate.ID)
                 event_list.append(choice(events["birth"]["affair"]))
         else:
             event_list.append(choice(events["birth"]["unmated_parent"]))
-
-        if "m_m" in cat_dict:
-            event_list = [event.replace("m_c's mate", "m_m") for event in event_list]
-        if "r_m" in cat_dict:
-            event_list = [event.replace("r_c's mate", "r_m") for event in event_list]
 
         if cheated_mate and other_cat and other_cat.ID not in cat.mate:
             if mate_claimed_kits:
@@ -823,20 +818,24 @@ class Pregnancy_Events:
                 )
         print_event = " ".join(event_list)
         print_event = print_event.replace("{insert}", insert)
+        if "mc_mate" in cat_dict:
+            print_event = print_event.replace("{mc_mate}", "mc_mate")
+        if "rc_mate" in cat_dict:
+            print_event = print_event.replace("{rc_mate}", "rc_mate")
 
         print_event = event_text_adjust(
             Cat, print_event, main_cat=cat, random_cat=other_cat, clan=game.clan
         )
         extra_cat_dict = {}
-        if "m_m" in cat_dict:
-            extra_cat_dict["m_m"] = (
-                str(cat_dict["m_m"].name),
-                choice(cat_dict["m_m"].pronouns),
+        if "mc_mate" in cat_dict:
+            extra_cat_dict["mc_mate"] = (
+                str(cat_dict["mc_mate"].name),
+                choice(cat_dict["mc_mate"].pronouns),
             )
-        if "r_m" in cat_dict:
-            extra_cat_dict["r_m"] = (
-                str(cat_dict["r_m"].name),
-                choice(cat_dict["r_m"].pronouns),
+        if "rc_mate" in cat_dict:
+            extra_cat_dict["rc_mate"] = (
+                str(cat_dict["rc_mate"].name),
+                choice(cat_dict["rc_mate"].pronouns),
             )
         if extra_cat_dict:
             print_event = process_text(print_event, extra_cat_dict)


### PR DESCRIPTION
### Motivation
- Make mate references used in pregnancy/birth events behave like the `{insert}` placeholder so names and pronouns are resolved consistently and simply.
- Avoid ad-hoc string rewrites of "m_c's mate" / "r_c's mate" by using explicit insert-style placeholders in event text.

### Description
- Replaced internal keys `m_m` / `r_m` with `mc_mate` / `rc_mate` when storing chosen mate cats in `scripts/events_module/relationship/pregnancy_events.py` so they act as insert-style tokens.
- Removed the older event-list string-replace steps that rewrote "m_c's mate" / "r_c's mate" and instead perform direct `{mc_mate}` / `{rc_mate}` → `mc_mate` / `rc_mate` substitution before text processing to match the existing `{insert}` flow.
- Added `extra_cat_dict` entries for `mc_mate` / `rc_mate` so `process_text` will insert the mate name and pronouns as before.
- Updated `resources/lang/en/conditions/pregnancy.json` strings to use `{mc_mate}` and `{rc_mate}` placeholders and adjusted pronoun tags to reference `mc_mate` / `rc_mate` where applicable.

### Testing
- Compiled the modified module with `python -m py_compile scripts/events_module/relationship/pregnancy_events.py` and it succeeded.
- Validated the JSON file with `python -m json.tool resources/lang/en/conditions/pregnancy.json >/dev/null` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded947d1f0832c9dfb1114ace6286e)