### PR TITLE
Handle unmated co-parenting birth outcomes and update relationships

### DIFF
--- a/resources/lang/en/conditions/pregnancy.en.json
+++ b/resources/lang/en/conditions/pregnancy.en.json
@@ -16,8 +16,8 @@
         "keep_clan_tradition": "%{name} decided to name the litter according to Clan tradition.",
         "reject_clan_tradition": "%{name} decided not to name the litter according to Clan tradition.",
         "affair_rel_log": "m_c found out that r_c cheated on {PRONOUN/m_c/object} and had kits with another cat.",
-        "unmated_coparenting_rel_log_neg": "m_c and r_c had a litter together and couldn't agree on co-parenting.",
-        "unmated_coparenting_rel_log_pos": "m_c and r_c became a little closer after they agreed on co-parenting their new litter together.",
+        "coparenting_rel_log_neg": "m_c and r_c had a litter together and couldn't agree on co-parenting.",
+        "coparenting_rel_log_pos": "m_c and r_c became a little closer after they agreed on co-parenting their new litter together.",
         "mate_claims_kits": "Despite being heartbroken over the fact that m_c cheated on {PRONOUN/r_c/object}, r_c still loves m_c too much to leave {PRONOUN/m_c/object} — r_c decides to help raise the %{insert}.",
         "mate_disowns_kits": "Heartbroken, angry, and confused, r_c decides that {PRONOUN/r_c/subject} isn't going to help m_c raise this %{insert} — they're not {PRONOUN/r_c/inposs} afterall."
     }

--- a/resources/lang/en/conditions/pregnancy.en.json
+++ b/resources/lang/en/conditions/pregnancy.en.json
@@ -16,6 +16,8 @@
         "keep_clan_tradition": "%{name} decided to name the litter according to Clan tradition.",
         "reject_clan_tradition": "%{name} decided not to name the litter according to Clan tradition.",
         "affair_rel_log": "m_c found out that r_c cheated on {PRONOUN/m_c/object} and had kits with another cat.",
+        "unmated_coparenting_rel_log_neg": "m_c and r_c had a litter together and couldn't agree on co-parenting.",
+        "unmated_coparenting_rel_log_pos": "m_c and r_c became a little closer after they agreed on co-parenting their new litter together.",
         "mate_claims_kits": "Despite being heartbroken over the fact that m_c cheated on {PRONOUN/r_c/object}, r_c still loves m_c too much to leave {PRONOUN/m_c/object} — r_c decides to help raise the %{insert}.",
         "mate_disowns_kits": "Heartbroken, angry, and confused, r_c decides that {PRONOUN/r_c/subject} isn't going to help m_c raise this %{insert} — they're not {PRONOUN/r_c/inposs} afterall."
     }

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -658,6 +658,7 @@ class Pregnancy_Events:
         Pregnancy_Events.rebuild_strings()
         events = Pregnancy_Events.PREGNANT_STRINGS
         event_list = []
+        unmated_coparenting_outcome = None
         if not cat.status.is_outsider and other_cat is None:
             event_list.append(choice(events["birth"]["unmated_parent"]))
         # birthing cat is outside the Clan
@@ -696,9 +697,12 @@ class Pregnancy_Events:
             involved_cats.append(other_cat.ID)
             cat_dict["r_c"] = other_cat
             # 50% chance for the event to have a poor reaction from either parent
-            if random.randint(0, 1): 
+            if random.randint(0, 1):
+                unmated_coparenting_outcome = "both_unmated_pos"
                 event_list.append(choice(events["birth"]["both_unmated_pos"]))
-            event_list.append(choice(events["birth"]["both_unmated_neg"]))
+            else:
+                unmated_coparenting_outcome = "both_unmated_neg"
+                event_list.append(choice(events["birth"]["both_unmated_neg"]))
             
         # affair birth event (same sex)
         elif not get_clan_setting("same sex birth") and has_female_mate and other_cat.ID not in cat.mate:        
@@ -919,6 +923,59 @@ class Pregnancy_Events:
                             "relationships.age_postscript",
                             name=str(other_cat.name),
                             count=other_cat.moons,
+                        )
+                    )
+
+        # Relationship changes for unmated co-parenting births
+        if (
+            other_cat
+            and len(cat.mate) < 1
+            and len(other_cat.mate) < 1
+            and not other_cat.dead
+            and unmated_coparenting_outcome
+        ):
+            for first_cat, second_cat in ((cat, other_cat), (other_cat, cat)):
+                rel = first_cat.relationships.get(second_cat.ID)
+                if not rel:
+                    rel = Relationship(first_cat, second_cat)
+                    first_cat.relationships[second_cat.ID] = rel
+
+                if unmated_coparenting_outcome == "both_unmated_neg":
+                    rel.comfort -= 30
+                    rel.trust -= 25
+                    if rel.romance > 0:
+                        rel.romance -= 20
+                    rel.log.append(
+                        process_text(
+                            i18n.t("conditions.pregnancy.unmated_coparenting_rel_log_neg"),
+                            {
+                                "m_c": (str(first_cat.name), choice(first_cat.pronouns)),
+                                "r_c": (str(second_cat.name), choice(second_cat.pronouns)),
+                            },
+                        )
+                        + i18n.t("relationships.negative_postscript")
+                        + i18n.t(
+                            "relationships.age_postscript",
+                            name=str(second_cat.name),
+                            count=second_cat.moons,
+                        )
+                    )
+                elif unmated_coparenting_outcome == "both_unmated_pos":
+                    rel.comfort += 20
+                    rel.trust += 20
+                    rel.log.append(
+                        process_text(
+                            i18n.t("conditions.pregnancy.unmated_coparenting_rel_log_pos"),
+                            {
+                                "m_c": (str(first_cat.name), choice(first_cat.pronouns)),
+                                "r_c": (str(second_cat.name), choice(second_cat.pronouns)),
+                            },
+                        )
+                        + i18n.t("relationships.positive_postscript")
+                        + i18n.t(
+                            "relationships.age_postscript",
+                            name=str(second_cat.name),
+                            count=second_cat.moons,
                         )
                     )
 

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -598,7 +598,7 @@ class Pregnancy_Events:
                 )
                 if mate_claimed_kits:
                     adoptive_parents.append(cheated_mate.ID)
-
+        coparenting_outcome = None
         kits = Pregnancy_Events.get_kits(
             kits_amount, cat, other_cat, clan, adoptive_parents=adoptive_parents
         )
@@ -658,7 +658,6 @@ class Pregnancy_Events:
         Pregnancy_Events.rebuild_strings()
         events = Pregnancy_Events.PREGNANT_STRINGS
         event_list = []
-        unmated_coparenting_outcome = None
         if not cat.status.is_outsider and other_cat is None:
             event_list.append(choice(events["birth"]["unmated_parent"]))
         # birthing cat is outside the Clan
@@ -698,10 +697,10 @@ class Pregnancy_Events:
             cat_dict["r_c"] = other_cat
             # 50% chance for the event to have a poor reaction from either parent
             if random.randint(0, 1):
-                unmated_coparenting_outcome = "both_unmated_pos"
+                coparenting_outcome = "positive"
                 event_list.append(choice(events["birth"]["both_unmated_pos"]))
             else:
-                unmated_coparenting_outcome = "both_unmated_neg"
+                coparenting_outcome = "negative"
                 event_list.append(choice(events["birth"]["both_unmated_neg"]))
             
         # affair birth event (same sex)
@@ -868,8 +867,8 @@ class Pregnancy_Events:
         if extra_cat_dict:
             print_event = process_text(print_event, extra_cat_dict)
 
-        # Relationship penalties for affair births
-        # Only apply if cat had mates AND other_cat is not one of them
+        # relationship changes for affair births
+        # this outcome here happens if the birthing cat cheated on their mate
         if other_cat and len(cat.mate) > 0 and other_cat.ID not in cat.mate:
             for mate_id in cat.mate:
                 mate = Cat.fetch_cat(mate_id)
@@ -897,8 +896,7 @@ class Pregnancy_Events:
                         )
                     )
 
-        # If OTHER_CAT had mates and CAT is not one of them,
-        # they also get a penalty for the affair
+        # if the other cat had a mate, they get penalites too
         if other_cat and len(other_cat.mate) > 0 and cat.ID not in other_cat.mate:
             for mate_id in other_cat.mate:
                 mate = Cat.fetch_cat(mate_id)
@@ -926,13 +924,13 @@ class Pregnancy_Events:
                         )
                     )
 
-        # Relationship changes for unmated co-parenting births
+        # relationship changes for unmated co-parenting births
         if (
             other_cat
             and len(cat.mate) < 1
             and len(other_cat.mate) < 1
             and not other_cat.dead
-            and unmated_coparenting_outcome
+            and coparenting_outcome
         ):
             for first_cat, second_cat in ((cat, other_cat), (other_cat, cat)):
                 rel = first_cat.relationships.get(second_cat.ID)
@@ -940,14 +938,14 @@ class Pregnancy_Events:
                     rel = Relationship(first_cat, second_cat)
                     first_cat.relationships[second_cat.ID] = rel
 
-                if unmated_coparenting_outcome == "both_unmated_neg":
+                if coparenting_outcome == "negative":
                     rel.comfort -= 30
                     rel.trust -= 25
                     if rel.romance > 0:
                         rel.romance -= 20
                     rel.log.append(
                         process_text(
-                            i18n.t("conditions.pregnancy.unmated_coparenting_rel_log_neg"),
+                            i18n.t("conditions.pregnancy.coparenting_rel_log_neg"),
                             {
                                 "m_c": (str(first_cat.name), choice(first_cat.pronouns)),
                                 "r_c": (str(second_cat.name), choice(second_cat.pronouns)),
@@ -960,12 +958,12 @@ class Pregnancy_Events:
                             count=second_cat.moons,
                         )
                     )
-                elif unmated_coparenting_outcome == "both_unmated_pos":
+                elif coparenting_outcome == "positive":
                     rel.comfort += 20
                     rel.trust += 20
                     rel.log.append(
                         process_text(
-                            i18n.t("conditions.pregnancy.unmated_coparenting_rel_log_pos"),
+                            i18n.t("conditions.pregnancy.coparenting_rel_log_pos"),
                             {
                                 "m_c": (str(first_cat.name), choice(first_cat.pronouns)),
                                 "r_c": (str(second_cat.name), choice(second_cat.pronouns)),
@@ -1007,7 +1005,7 @@ class Pregnancy_Events:
 
     @staticmethod
     def get_first_mate(subject_cat: Cat, include_dead: bool = False):
-        """ Gets the mate of the cheating cat for the events"""
+        """ Gets cheating cat's mate for the events"""
         for mate_id in subject_cat.mate:
             mate = Cat.fetch_cat(mate_id)
             if not mate:
@@ -1018,7 +1016,7 @@ class Pregnancy_Events:
 
     @staticmethod
     def should_claim_affair_kits(mate: Cat, pregnant_cat: Cat) -> bool:
-        """Determines if a mate chooses to claim kits after an affair birth."""
+        """Determines if the mate chooses to claim kits after an affair birth."""
         if not mate or mate.dead:
             return False
 


### PR DESCRIPTION
### Motivation
- Fix incorrect event selection for unmated co-parenting births and add relationship consequences for those outcomes.
- Provide localized strings for positive and negative unmated co-parenting logs to surface appropriate player-facing text.

### Description
- Add two new localization keys `conditions.pregnancy.unmated_coparenting_rel_log_neg` and `conditions.pregnancy.unmated_coparenting_rel_log_pos` to English resources.
- Introduce `unmated_coparenting_outcome` to capture the random positive/negative outcome and fix a bug where both positive and negative messages could be appended by making the negative branch an `else`.
- Apply relationship creation or updates between the two unmated parents after birth, adjusting `comfort`, `trust`, and `romance`, and appending the appropriate localized log and postscript based on the outcome.

### Testing
- Ran the project's test suite with `pytest -q` and all tests passed. 
- Ran a localization load check to verify the new keys are present and formatted correctly, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69def8b7891c832c8e203b93b3666f8d)