### PR TITLE
Fix affair litter adoptive parent assignment

### DIFF
--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -1556,8 +1556,14 @@ class Pregnancy_Events:
         # add them as adoptive parents if not
         final_adoptive_parents = []
         for adoptive_p in all_adoptive_parents:
-            Cat.fetch_cat(adoptive_p).get_new_thought(CatThought.ON_BIRTH)
-            if adoptive_p not in all_kitten[0].inheritance.all_involved:
+            adoptive_cat = Cat.fetch_cat(adoptive_p)
+            if not adoptive_cat:
+                continue
+
+            adoptive_cat.get_new_thought(CatThought.ON_BIRTH)
+            # Allow mates/relatives of blood parents to still be recorded as
+            # adoptive parents. We only skip true birth parents.
+            if adoptive_p not in all_kitten[0].get_parents():
                 final_adoptive_parents.append(adoptive_p)
         if not adoptive_parents:
             cat.get_new_thought(CatThought.ON_BIRTH)

--- a/tests/test_relation_events.py
+++ b/tests/test_relation_events.py
@@ -127,6 +127,28 @@ class Pregnancy(unittest.TestCase):
         self.assertEqual(clan.pregnancy_data[cat1.ID]["second_parent"], cat2.ID)
 
 
+class AffairKitsAdoption(unittest.TestCase):
+    def test_cheated_mate_can_be_added_as_adoptive_parent(self):
+        clan = Clan(name="clan")
+        birthing_cat = Cat(gender="female", age="adult", moons=40, disable_random=True)
+        affair_cat = Cat(gender="male", age="adult", moons=40, disable_random=True)
+        cheated_mate = Cat(gender="male", age="adult", moons=40, disable_random=True)
+
+        birthing_cat.mate.append(cheated_mate.ID)
+        cheated_mate.mate.append(birthing_cat.ID)
+
+        kits = Pregnancy_Events.get_kits(
+            2,
+            birthing_cat,
+            affair_cat,
+            clan,
+            adoptive_parents=[cheated_mate.ID],
+        )
+
+        for kit in kits:
+            self.assertIn(cheated_mate.ID, kit.adoptive_parents)
+
+
 class Mates(unittest.TestCase):
     def test_platonic_kitten_mating(self):
         # given


### PR DESCRIPTION
### Motivation
- The cheated mate who chooses to help raise kits from an affair was not being recorded as an adoptive parent because adoptive-parent filtering excluded cats present in inherited family data rather than only true birth parents. 
- A missing-cat case could also cause an error when attempting to call `get_new_thought` on a non-existent adoptive ID. 

### Description
- In `Pregnancy_Events.get_kits` updated the adoptive-parent filtering to fetch the adoptive cat, skip missing IDs, call `get_new_thought` safely, and only exclude true birth parents by checking `all_kitten[0].get_parents()` instead of `inheritance.all_involved`. 
- Added a guard to `continue` when `Cat.fetch_cat(adoptive_p)` returns `None` before applying thought/assignment logic. 
- Added a regression test `AffairKitsAdoption.test_cheated_mate_can_be_added_as_adoptive_parent` in `tests/test_relation_events.py` to assert a cheated mate passed via `adoptive_parents` is assigned to each kit.

### Testing
- Compiled the modified modules with `python -m compileall scripts/events_module/relationship/pregnancy_events.py tests/test_relation_events.py` which succeeded. 
- Ran `pytest -q tests/test_relation_events.py -k "AffairKitsAdoption or Pregnancy"` but test collection failed in this environment due to a missing external dependency (`i18n`), so the new test could not be executed here. 
- Changes were committed locally with the message `Fix affair litter adoptive parent assignment`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e144e40028832c8fd893281921a220)