### PR TITLE
Fix apprentice timeskip crash when experience is None

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -2103,6 +2103,11 @@ def handle_apprentice_EX(cat):
         if cat.not_working() and int(random.random() * 3):
             return
 
+        # Older/externally edited saves can leave experience unset (None) on loaded cats.
+        # Normalize before comparing to avoid None > int crashes during timeskip.
+        if cat.experience is None:
+            cat.experience = 0
+
         if cat.experience > cat.experience_levels_range["trainee"][1]:
             return
 


### PR DESCRIPTION
### Motivation
- Prevent a `TypeError` when `handle_apprentice_EX` compares `cat.experience` to the trainee range if `cat.experience` is `None`; no AGENTS skills were used.

### Description
- Normalize unset `cat.experience` to `0` before the trainee-level comparison in `scripts/events.py` to avoid `None > int` crashes during timeskip.

### Testing
- Compiled `scripts/events.py` with `python -m compileall` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1b0d7ef78832cb7e4670c6a551568)