### PR TITLE
Fix missing adoptive parent when mate claims affair kits

### DIFF
--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -711,9 +711,6 @@ class Pregnancy_Events:
         other_cat_id = clan.pregnancy_data[cat.ID]["second_parent"]
         other_cat = Cat.all_cats.get(other_cat_id)
 
-        kits = Pregnancy_Events.get_kits(kits_amount, cat, other_cat, clan)
-        kits_amount = len(kits)
-        Pregnancy_Events.set_biggest_family()
         extra_naming_text = None
         has_afab_mate = any(
             Cat.fetch_cat(mate_id) and Cat.fetch_cat(mate_id).gender == "female"
@@ -742,6 +739,12 @@ class Pregnancy_Events:
                     if mate_claimed_kits:
                         adoptive_parents.append(cheated_mate.ID)
         coparenting_outcome = None
+
+        kits = Pregnancy_Events.get_kits(
+            kits_amount, cat, other_cat, clan, adoptive_parents=adoptive_parents
+        )
+        kits_amount = len(kits)
+        Pregnancy_Events.set_biggest_family()
 
         # delete the cat out of the pregnancy dictionary
         del clan.pregnancy_data[cat.ID]


### PR DESCRIPTION
### Motivation
- Fix a bug where a cheated mate who claims kits after an affair was not being recorded as an adoptive parent because kittens were generated before the claim was resolved.

### Description
- Resolve affair/claim logic before kitten generation and pass `adoptive_parents` into `get_kits(...)` so claimed mates are included as adoptive parents and `kits_amount`/family state are updated afterwards.

### Testing
- Compiled the modified module with `python -m py_compile scripts/events_module/relationship/pregnancy_events.py` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e248ecd0832cac8fb065dd6ec77a)