### PR TITLE
Exclude unmentioned mates from pregnancy event involved_cats

### DIFF
--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -79,6 +79,17 @@ class Pregnancy_Events:
         return involved_cats
 
     @staticmethod
+    def prune_unmentioned_mate_ids(
+        involved_cats: List[str], event_text: str, cat_dict: Dict
+    ) -> List[str]:
+        """Removes mate IDs if their placeholder is not present in the final event text."""
+        for placeholder in ("mc_mate", "rc_mate"):
+            cat = cat_dict.get(placeholder)
+            if cat and placeholder not in event_text and cat.ID in involved_cats:
+                involved_cats.remove(cat.ID)
+        return involved_cats
+
+    @staticmethod
     def get_cheated_mate(subject_cat: Cat, include_dead: bool = False):
         """Gets cheating cat's mate for the events"""
         for mate_id in subject_cat.mate:
@@ -1010,6 +1021,10 @@ class Pregnancy_Events:
             print_event = print_event.replace("mc_mate", "mc_mate")
         if "rc_mate" in cat_dict:
             print_event = print_event.replace("rc_mate", "rc_mate")
+
+        involved_cats = Pregnancy_Events.prune_unmentioned_mate_ids(
+            involved_cats, print_event, cat_dict
+        )
 
         print_event = event_text_adjust(
             Cat, print_event, main_cat=cat, random_cat=other_cat, clan=game.clan

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -79,10 +79,10 @@ class Pregnancy_Events:
         return involved_cats
 
     @staticmethod
-    def prune_unmentioned_mate_ids(
+    def remove_unmentioned_mate_ids(
         involved_cats: List[str], event_text: str, cat_dict: Dict
     ) -> List[str]:
-        """Removes mate IDs if their placeholder is not present in the final event text."""
+        """Removes the cheated mate's TD if mc/rc_mate isn't present in the affair birth event text."""
         for placeholder in ("mc_mate", "rc_mate"):
             cat = cat_dict.get(placeholder)
             if cat and placeholder not in event_text and cat.ID in involved_cats:
@@ -1022,7 +1022,7 @@ class Pregnancy_Events:
         if "rc_mate" in cat_dict:
             print_event = print_event.replace("rc_mate", "rc_mate")
 
-        involved_cats = Pregnancy_Events.prune_unmentioned_mate_ids(
+        involved_cats = Pregnancy_Events.remove_unmentioned_mate_ids(
             involved_cats, print_event, cat_dict
         )
 


### PR DESCRIPTION
### Motivation
- Birth event text sometimes references only one mate placeholder (e.g. `r_c`) while the event `involved_cats` list still included other mate IDs, causing unrelated mates to appear in the event UI.

### Description
- Add `prune_unmentioned_mate_ids(involved_cats, event_text, cat_dict)` to `Pregnancy_Events` to remove `mc_mate`/`rc_mate` IDs when their placeholders are not present in the selected event text.
- Call the pruning step right before `event_text_adjust` / event emission so `involved_cats` matches the final `print_event` content.
- Changes applied in `scripts/events_module/relationship/pregnancy_events.py` and leave existing `append_second_parent_if_mentioned` behavior unchanged.

### Testing
- Compiled the modified file with `python -m compileall scripts/events_module/relationship/pregnancy_events.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ffe16de0832c9999e02bb90e8106)