### PR TITLE
Restrict medicine cats from taking mates and suppress romance gains

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2860,6 +2860,13 @@ class Cat:
         if not ignore_no_mates and (self.no_mates or other_cat.no_mates):
             return False
 
+        # Medicine cats and medicine cat apprentices cannot take new mates.
+        if (
+            self.status.rank.is_any_medicine_rank()
+            or other_cat.status.rank.is_any_medicine_rank()
+        ):
+            return False
+
         # Inheritance check
         if self.is_related(other_cat, first_cousin_mates):
             return False

--- a/scripts/events_module/relationship/romantic_events.py
+++ b/scripts/events_module/relationship/romantic_events.py
@@ -210,9 +210,17 @@ class RomanticEvents:
         value_change = "increase" if positive else "decrease"
         rel_type = RelType.ROMANCE
         relationship.chosen_interaction = chosen_interaction
-        relationship.interaction_affect_relationships(
-            positive, chosen_interaction.intensity, rel_type
-        )
+        intensity = chosen_interaction.intensity
+        if (
+            positive
+            and (
+                cat_from.status.rank.is_any_medicine_rank()
+                or cat_to.status.rank.is_any_medicine_rank()
+            )
+            and random_module.randint(1, 12) != 1
+        ):
+            intensity = 0
+        relationship.interaction_affect_relationships(positive, intensity, rel_type)
 
         # give cats injuries
         if len(chosen_interaction.get_injuries) > 0:


### PR DESCRIPTION
### Motivation

- Enforce book-accurate behavior where medicine cats (and apprentices) do not take mates and gain romance only very rarely from normal romantic events, while allowing medicine-specific romance patrols to remain functional.

### Description

- Added an early return in `Cat.is_potential_mate` to block cats with medicine ranks from being considered potential mates in `scripts/cat/cats.py`.
- Suppressed positive romance gains in `scripts/events_module/relationship/romantic_events.py` by zeroing out the interaction intensity for positive romantic interactions involving a medicine-ranked cat except on a rare 1-in-12 chance.
- Kept patrol-generation and patrol-based romance logic unchanged so medical romance patrols continue to function.
- Modified files: `scripts/cat/cats.py` and `scripts/events_module/relationship/romantic_events.py`.

### Testing

- Ran `python -m compileall scripts/cat/cats.py scripts/events_module/relationship/romantic_events.py` and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf00bfff4832c95d861c28f6459aa)