### PR TITLE
Reduce murderer mate romance on murder reveal

### DIFF
--- a/scripts/events_module/short/short_event.py
+++ b/scripts/events_module/short/short_event.py
@@ -324,6 +324,17 @@ class ShortEvent:
                 clan_reveal="clan_wide" in self.tags,
                 aware_individuals=[self.random_cat.ID],
             )
+            murderer_mates = []
+            for mate_id in self.main_cat.mate:
+                mate = Cat.fetch_cat(mate_id)
+                if mate and not mate.dead:
+                    murderer_mates.append(mate)
+            if murderer_mates:
+                change_relationship_values(
+                    [self.main_cat],
+                    murderer_mates,
+                    romance=-80,
+                )
 
         # change outsider rep
         if self.outsider:


### PR DESCRIPTION
### Motivation
- Ensure that when a murder is revealed, any living mate(s) of the murderer lose a large amount of romantic feeling toward the murderer to reflect the social impact of the reveal.

### Description
- Added logic to `scripts/events_module/short/short_event.py` inside the `murder_reveal`/`hidden_murder_reveal` handling to collect living mates via `Cat.fetch_cat` and apply `change_relationship_values([self.main_cat], murderer_mates, romance=-80)` so mates lose a large amount of romance toward the murderer.

### Testing
- Compiled the modified module with `python -m compileall scripts/events_module/short/short_event.py` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf1132164832ca8f07eea287699f7)