### PR TITLE
Prevent queens with very young kits (<=5 moons) from being selectable for patrols

### DIFF
--- a/scripts/clan_package/get_clan_cats.py
+++ b/scripts/clan_package/get_clan_cats.py
@@ -45,6 +45,18 @@ def get_alive_clan_queens(living_cats):
     return queen_dict, living_kits
 
 
+def get_queens_with_young_kits(living_cats, max_kit_moons: int) -> set:
+    """
+    Returns a set of queen IDs that currently have at least one kit with moons <= max_kit_moons.
+    """
+    queen_dict, _ = get_alive_clan_queens(living_cats)
+    return {
+        queen_id
+        for queen_id, kits in queen_dict.items()
+        if any(kit.moons <= max_kit_moons for kit in kits)
+    }
+
+
 def find_alive_cats_with_rank(
     Cat: Union["Cat", Type["Cat"]],
     ranks: list,

--- a/scripts/screens/PatrolScreen.py
+++ b/scripts/screens/PatrolScreen.py
@@ -17,6 +17,7 @@ from ..ui.scale import ui_scale, ui_scale_dimensions
 from .Screens import Screens
 from .enums import GameScreen
 from ..clan_package.settings import get_clan_setting
+from ..clan_package.get_clan_cats import get_queens_with_young_kits
 from ..game_structure import image_cache, constants
 from ..game_structure.game.switches import switch_set_value, Switch
 from ..game_structure.game.settings import game_setting_get
@@ -1010,6 +1011,10 @@ class PatrolScreen(Screens):
 
         self.able_cats = []
 
+        queens_with_young_kits = get_queens_with_young_kits(
+            Cat.all_cats_list, max_kit_moons=5
+        )
+
         # ASSIGN TO ABLE CATS
         for the_cat in Cat.all_cats_list:
             if (
@@ -1019,6 +1024,7 @@ class PatrolScreen(Screens):
                 and the_cat.status.alive_in_player_clan
                 and the_cat not in self.current_patrol
                 and not the_cat.not_working()
+                and the_cat.ID not in queens_with_young_kits
             ):
                 if (
                     the_cat.status.rank == CatRank.NEWBORN

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -13,7 +13,10 @@ from scripts.events_module.event_filters import (
     get_highest_romantic_relation,
     get_personality_compatibility,
 )
-from scripts.clan_package.get_clan_cats import get_alive_clan_queens
+from scripts.clan_package.get_clan_cats import (
+    get_alive_clan_queens,
+    get_queens_with_young_kits,
+)
 
 
 class TestPersonalityCompatibility(unittest.TestCase):
@@ -385,4 +388,21 @@ class TestGetQueens(unittest.TestCase):
         ]
         self.assertEqual(
             [self.test_cat2.ID], list(get_alive_clan_queens(living_cats)[0].keys())
+        )
+
+    def test_get_queens_with_young_kits_filters_by_age(self):
+        self.test_cat1.gender = "female"
+        self.test_cat2.status._change_rank(CatRank.KITTEN)
+        self.test_cat2.parent1 = self.test_cat1.ID
+        self.test_cat2.moons = 5
+
+        self.test_cat3.gender = "female"
+        self.test_cat4.status._change_rank(CatRank.KITTEN)
+        self.test_cat4.parent1 = self.test_cat3.ID
+        self.test_cat4.moons = 6
+
+        living_cats = [self.test_cat1, self.test_cat2, self.test_cat3, self.test_cat4]
+
+        self.assertEqual(
+            {self.test_cat1.ID}, get_queens_with_young_kits(living_cats, 5)
         )


### PR DESCRIPTION
### Motivation
- Queens that are actively caring for very young kits should not be selectable for patrols to reflect caregiving responsibilities.

### Description
- Added `get_queens_with_young_kits(living_cats, max_kit_moons)` in `scripts/clan_package/get_clan_cats.py` to return queen IDs that have at least one kit with `moons <= max_kit_moons`.
- Updated patrol eligibility in `scripts/screens/PatrolScreen.py` to call `get_queens_with_young_kits(Cat.all_cats_list, max_kit_moons=5)` and exclude those queen IDs from `able_cats`.
- Added a unit test `test_get_queens_with_young_kits_filters_by_age` in `tests/test_utility.py` to assert that a kit with 5 moons is considered while one with 6 moons is not.

### Testing
- Compiled the modified files with `python -m compileall scripts/clan_package/get_clan_cats.py scripts/screens/PatrolScreen.py tests/test_utility.py` which succeeded.
- Ran `pytest -q tests/test_utility.py -k queens_with_young_kits` but test collection failed due to a missing dependency (`ModuleNotFoundError: No module named 'strenum'`) in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0f1cc7f0832c91a099cd215ab3de)