### PR TITLE
Treat None experience as 0 in patrol success calculation

### DIFF
--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -939,7 +939,8 @@ class Patrol:
         """Returns both the chosen event, and a boolean that's True if success, and False is fail."""
 
         patrol_size = len(self.patrol_cats)
-        total_exp = sum([x.experience for x in self.patrol_cats])
+        # Some cats can have an unset experience value (None), so treat that as 0.
+        total_exp = sum(x.experience or 0 for x in self.patrol_cats)
         gm_modifier = constants.CONFIG["patrol_generation"][
             f"{game.clan.game_mode}_difficulty_modifier"
         ]


### PR DESCRIPTION
### Motivation
- Prevent a `TypeError` in `calculate_success` when some patrol cats have `experience = None` by ensuring total experience sums don't mix `int` and `NoneType`.

### Description
- Replace `sum([x.experience for x in self.patrol_cats])` with `sum(x.experience or 0 for x in self.patrol_cats)` and add an inline comment explaining that missing experience values are treated as `0`.

### Testing
- Compiled the module with `python -m compileall scripts/events_module/patrol/patrol.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed83074cd0832c829bc663498f9cdb)