### PR TITLE
Skip kits already in player clan when adding outsider

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -1245,6 +1245,7 @@ class Cat:
             child = Cat.all_cats[child_id]
             if (
                 not child.dead
+                and not child.status.alive_in_player_clan
                 and not child.status.is_exiled(CatGroup.PLAYER_CLAN_ID)
                 and child.moons < 12
             ):


### PR DESCRIPTION
### Motivation
- Prevent outsider parents from “bringing their litter” and creating duplicate adoption processing for kits that are already `alive_in_player_clan` (for example, after an abandoned-litter adoption flow).

### Description
- Add an explicit guard `not child.status.alive_in_player_clan` to `Cat.add_to_clan()` in `scripts/cat/cats.py` so children already in the player clan are not re-imported.

### Testing
- Attempted to run the related pytest selection, but test collection failed in this environment due to a missing dependency (`ujson`), so automated verification could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f26311f0e4832cab58c81b9af23ce3)