### PR TITLE
Slightly increase pregnancy chance when clan lacks very young cats

### DIFF
--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -2136,6 +2136,15 @@ class Pregnancy_Events:
         if avg_age > 80:
             inverse_chance = int(inverse_chance * 0.8)
 
+        # - slightly decrease inverse chance if the clan has no very young cats yet
+        alive_clan_cats = [
+            i for i in Cat.all_cats.values() if i.status.alive_in_player_clan
+        ]
+        if alive_clan_cats:
+            youngest_cat_age = min(i.moons for i in alive_clan_cats)
+            if youngest_cat_age > 24:
+                inverse_chance = int(inverse_chance * 0.9)
+
         # If any of the mated cats have the 'KIT' skill, they're more likely to have kits because, well... they love kits no? TBD
         
         # If the parent(s) are young adults, the chance for kits is higher because the hormones are still raging lmao


### PR DESCRIPTION
### Motivation
- Encourage more births when the player clan has no very young cats by slightly increasing the pregnancy chance in the existing pregnancy calculation.

### Description
- Add a check in `scripts/events_module/relationship/pregnancy_events.py` that collects alive player-clan cats, finds the youngest cat's `moons`, and if the youngest is older than 24 moons reduces `inverse_chance` by 10% via `inverse_chance = int(inverse_chance * 0.9)` so pregnancies become slightly more likely.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f263ff0730832ca133cd3b323fa951)