### PR TITLE
Warn low med-cats based on current cases, not whole clan

### DIFF
--- a/scripts/conditions.py
+++ b/scripts/conditions.py
@@ -63,6 +63,20 @@ def medicine_cats_can_cover_clan(all_cats, amount_per_med) -> bool:
     return amount_clanmembers_covered(all_cats, amount_per_med) >= len(relevant_cats)
 
 
+def medicine_cats_can_cover_condition_cases(all_cats, amount_per_med) -> bool:
+    """
+    whether the player has enough meds for the currently sick/injured cats,
+    including cats with permanent conditions
+    """
+    relevant_cats = [
+        c
+        for c in all_cats
+        if c.status.alive_in_player_clan
+        and (c.is_ill() or c.is_injured() or bool(c.permanent_condition))
+    ]
+    return amount_clanmembers_covered(all_cats, amount_per_med) >= len(relevant_cats)
+
+
 def get_amount_cat_for_one_medic(clan):
     """Returns the amount of cats one medicine cat can treat"""
     amount = 10

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -32,6 +32,7 @@ from scripts.clan_package.settings import get_clan_setting, set_clan_setting
 from scripts.clan_resources.freshkill import FRESHKILL_EVENT_ACTIVE
 from scripts.conditions import (
     amount_clanmembers_covered,
+    medicine_cats_can_cover_condition_cases,
     medicine_cats_can_cover_clan,
     get_amount_cat_for_one_medic,
 )
@@ -287,7 +288,7 @@ def one_moon():
 
     if game.clan.game_mode in ("expanded", "cruel season"):
         amount_per_med = get_amount_cat_for_one_medic(game.clan)
-        med_fulfilled = medicine_cats_can_cover_clan(
+        med_fulfilled = medicine_cats_can_cover_condition_cases(
             Cat.all_cats.values(), amount_per_med
         )
 


### PR DESCRIPTION
### Motivation
- The low-medicine-cat warning should reflect whether current care demand (sick, injured, or permanent-condition cats) is covered, not whether there are enough med cats for the entire clan.

### Description
- Added `medicine_cats_can_cover_condition_cases(all_cats, amount_per_med)` in `scripts/conditions.py` to compute capacity against only cats that currently need care (alive and `is_ill()` or `is_injured()` or have a `permanent_condition`).
- Updated `scripts/events.py` to import and use `medicine_cats_can_cover_condition_cases` in the moon processing path for `expanded`/`cruel season` modes instead of `medicine_cats_can_cover_clan` so the low-med warning is only shown when current cases exceed capacity.
- Modified files: `scripts/conditions.py`, `scripts/events.py`.

### Testing
- Attempted to run `pytest -q tests/test_conditions.py`, but test collection failed due to a missing test dependency (`ModuleNotFoundError: No module named 'ujson'`), so automated tests could not complete in this environment.
- No automated test failures related to the change were observed because the test run was blocked by the missing dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f26adf53a8832cafe6b0005e9bc4f1)