### PR TITLE
Restore patrol outcome persistence and refresh clan save button after patrol

### DIFF
--- a/scripts/screens/PatrolScreen.py
+++ b/scripts/screens/PatrolScreen.py
@@ -316,8 +316,7 @@ class PatrolScreen(Screens):
         if (
             self.in_progress_data is not None
             and self.in_progress_data["current_moon"] == game.clan.age
-            and self.in_progress_data["clan_name"]
-            == i18n.t("general.clan", clan=game.clan.displayname)
+            and self.in_progress_data["clan_name"] == game.clan.name
         ):
             self.display_change_load(self.in_progress_data)
         else:
@@ -935,6 +934,9 @@ class PatrolScreen(Screens):
 
     def run_patrol_proceed(self, user_input):
         """Proceeds the patrol - to be run in the separate thread."""
+        # Patrol resolution changes save data/state, so mark save as outdated.
+        switch_set_value(Switch.saved_clan, False)
+
         if user_input in ["nopro", "notproceed"]:
             (
                 self.display_text,


### PR DESCRIPTION
### Motivation
- Returning to the Patrol screen after navigating away no longer restored the just-completed patrol outcome because the saved in-progress clan identifier was compared to a translated clan display string instead of the internal clan name.
- Completing a patrol can change game state but the Clan screen save button sometimes remained showing the "saved" state, causing a stale UI state after patrol resolution.

### Description
- Use the internal clan name for in-progress patrol restoration by comparing `variable_dict["clan_name"]` to `game.clan.name` in `screen_switches` of `scripts/screens/PatrolScreen.py`.
- Mark the clan as unsaved when resolving a patrol by calling `switch_set_value(Switch.saved_clan, False)` at the start of `run_patrol_proceed` so the Clan screen save button refreshes to the unsaved state.
- Changes are contained to `scripts/screens/PatrolScreen.py` and are limited to the screen-switch/load and patrol resolution paths.

### Testing
- Compiled the edited file with `python -m py_compile scripts/screens/PatrolScreen.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bb13a5104832c83e19845f4c35315)