### PR TITLE
Add mentor/apprentice relationship boost and rel-log variants

### DIFF
--- a/resources/lang/en/relationships.en.json
+++ b/resources/lang/en/relationships.en.json
@@ -56,6 +56,11 @@
             "one": "%{text} - %{name} was %{count} moon old",
             "many": "%{text} - %{name} was %{count} moons old"
         },
-        "relationship_log": "These cats recently interacted."
+        "relationship_log": "These cats recently interacted.",
+        "mentor_rel_log": "m_c became the apprentice of r_c.",
+        "mentor_rel_log_options": [
+            "m_c became the apprentice of r_c.",
+            "m_c was apprenticed to r_c."
+        ]
     }
 }

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2778,6 +2778,12 @@ class Cat:
         if self.ID not in mentor_cat.apprentice:
             mentor_cat.apprentice.append(self.ID)
 
+    def __build_mentor_rel_log(self, mentor_cat: Cat) -> str:
+        rel_log_options = i18n.t("relationships.mentor_rel_log_options")
+        if isinstance(rel_log_options, list) and rel_log_options:
+            return choice(rel_log_options)
+        return i18n.t("relationships.mentor_rel_log")
+
     def update_mentor(self, new_mentor: Any = None):
         """Takes mentor's ID as argument, mentor could just be set via this function."""
         # No !!
@@ -2798,6 +2804,44 @@ class Cat:
         if new_mentor:
             self.__remove_mentor()
             self.__add_mentor(new_mentor)
+            mentor_cat = Cat.fetch_cat(self.mentor)
+            if mentor_cat:
+                rel_log = event_text_adjust(
+                    Cat,
+                    self.__build_mentor_rel_log(mentor_cat),
+                    main_cat=self,
+                    random_cat=mentor_cat,
+                )
+
+                if mentor_cat.ID not in self.relationships:
+                    self.create_one_relationship(mentor_cat)
+                if self.ID not in mentor_cat.relationships:
+                    mentor_cat.create_one_relationship(self)
+
+                app_relationship = self.relationships[mentor_cat.ID]
+                mentor_relationship = mentor_cat.relationships[self.ID]
+
+                app_relationship.like += 5
+                app_relationship.trust += 5
+                app_relationship.log.append(
+                    i18n.t(
+                        "relationships.age_postscript",
+                        text=rel_log,
+                        name=mentor_cat.name,
+                        count=mentor_cat.moons,
+                    )
+                )
+
+                mentor_relationship.like += 5
+                mentor_relationship.respect += 5
+                mentor_relationship.log.append(
+                    i18n.t(
+                        "relationships.age_postscript",
+                        text=rel_log,
+                        name=self.name,
+                        count=self.moons,
+                    )
+                )
 
         # Check if current mentor is valid
         if self.mentor:

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -456,6 +456,34 @@ class TestUpdateMentor(unittest.TestCase):
 
         self.assertTrue(app.is_valid_mentor(mentor))
 
+    def test_update_mentor_increases_relationship_and_adds_log(self):
+        app = Cat(
+            moons=7, status_dict={"rank": CatRank.APPRENTICE}, disable_random=True
+        )
+        mentor = Cat(
+            moons=30, status_dict={"rank": CatRank.WARRIOR}, disable_random=True
+        )
+
+        app.update_mentor(mentor.ID)
+
+        self.assertIn(mentor.ID, app.relationships)
+        self.assertIn(app.ID, mentor.relationships)
+        self.assertGreaterEqual(app.relationships[mentor.ID].like, 5)
+        self.assertGreaterEqual(app.relationships[mentor.ID].trust, 5)
+        self.assertGreaterEqual(mentor.relationships[app.ID].like, 5)
+        self.assertGreaterEqual(mentor.relationships[app.ID].respect, 5)
+
+        app_logs = " ".join(app.relationships[mentor.ID].log)
+        mentor_logs = " ".join(mentor.relationships[app.ID].log)
+        self.assertTrue(
+            ("became the apprentice of" in app_logs)
+            or ("was apprenticed to" in app_logs)
+        )
+        self.assertTrue(
+            ("became the apprentice of" in mentor_logs)
+            or ("was apprenticed to" in mentor_logs)
+        )
+
 
 class TestNameRepr(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
### Motivation
- Ensure that when an apprentice is assigned a mentor via `update_mentor`, both cats receive a small, immediate relationship boost and the relationship log records the assignment with varied phrasing.

### Description
- Add `__build_mentor_rel_log` to `Cat` to pick a mentor-assignment rel-log variant from localization keys and fall back to a default string.
- When `update_mentor(new_mentor=...)` sets a mentor, create missing `Relationship` objects for both cats, apply small stat changes (`apprentice: like +5, trust +5`; `mentor: like +5, respect +5`), and append an age-postscripted rel-log entry using `event_text_adjust` and the chosen variant.
- Add English localization entries `mentor_rel_log` and `mentor_rel_log_options` to `resources/lang/en/relationships.en.json` with the two variants "m_c became the apprentice of r_c." and "m_c was apprenticed to r_c.".
- Add unit test `test_update_mentor_increases_relationship_and_adds_log` in `tests/test_cat.py` to assert relationship creation, stat increases, and that one of the log variants appears in both cats' relationship logs.

### Testing
- Ran `pytest -q tests/test_cat.py::TestUpdateMentor` to exercise the new test, but the test run failed in this environment with `ModuleNotFoundError: No module named 'pygame'`, so automated assertions could not be completed here.
- The changes and test were added and saved to the repository; the new test verifies relationships and log text when run in a full environment with dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bb30ee090832c8957a9f9d9e9a791)