### PR TITLE
Persist patrol clan name and mark save dirty when resolving patrols

### DIFF
--- a/scripts/screens/PatrolScreen.py
+++ b/scripts/screens/PatrolScreen.py
@@ -316,8 +316,10 @@ class PatrolScreen(Screens):
         if (
             self.in_progress_data is not None
             and self.in_progress_data["current_moon"] == game.clan.age
-            and self.in_progress_data["clan_name"]
-            == i18n.t("general.clan", clan=game.clan.displayname)
+            and self.in_progress_data.get(
+                "patrol_clan_name", self.in_progress_data.get("clan_name")
+            )
+            == game.clan.name
         ):
             self.display_change_load(self.in_progress_data)
         else:
@@ -352,7 +354,7 @@ class PatrolScreen(Screens):
         variable_dict["outcome_art"] = self.outcome_art
 
         variable_dict["current_moon"] = game.clan.age
-        variable_dict["clan_name"] = game.clan.name
+        variable_dict["patrol_clan_name"] = game.clan.name
 
         return variable_dict
 
@@ -935,6 +937,9 @@ class PatrolScreen(Screens):
 
     def run_patrol_proceed(self, user_input):
         """Proceeds the patrol - to be run in the separate thread."""
+        # Patrol resolution changes save data/state, so mark save as outdated.
+        switch_set_value(Switch.saved_clan, False)
+
         if user_input in ["nopro", "notproceed"]:
             (
                 self.display_text,


### PR DESCRIPTION
### Motivation
- Ensure in-progress patrols are correctly recognized across screen switches by storing and comparing the clan's internal name instead of a localized display string.
- Make sure the game's saved state is marked outdated when a patrol is resolved so the changed clan data will be persisted.

### Description
- Change `display_change_save` to store `patrol_clan_name = game.clan.name` instead of the previous `clan_name` key.
- Update `screen_switches` to compare `in_progress_data.get("patrol_clan_name", in_progress_data.get("clan_name"))` to `game.clan.name` when deciding to reload an in-progress patrol.
- Add `switch_set_value(Switch.saved_clan, False)` at the start of `run_patrol_proceed` to mark the save as outdated whenever patrol resolution runs.
- Keep existing patrol proceed logic intact while ensuring state/save handling is consistent.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bb13a5104832c83e19845f4c35315)