### PR TITLE
PatrolScreen: persist raw clan name, rebuild heading on load, and mark save dirty on proceed

### DIFF
--- a/scripts/screens/PatrolScreen.py
+++ b/scripts/screens/PatrolScreen.py
@@ -316,8 +316,10 @@ class PatrolScreen(Screens):
         if (
             self.in_progress_data is not None
             and self.in_progress_data["current_moon"] == game.clan.age
-            and self.in_progress_data["clan_name"]
-            == i18n.t("general.clan", clan=game.clan.displayname)
+            and self.in_progress_data.get(
+                "patrol_clan_name", self.in_progress_data.get("clan_name")
+            )
+            == game.clan.name
         ):
             self.display_change_load(self.in_progress_data)
         else:
@@ -352,12 +354,17 @@ class PatrolScreen(Screens):
         variable_dict["outcome_art"] = self.outcome_art
 
         variable_dict["current_moon"] = game.clan.age
-        variable_dict["clan_name"] = game.clan.name
+        variable_dict["patrol_clan_name"] = game.clan.name
 
         return variable_dict
 
     def display_change_load(self, variable_dict: Dict):
         super().display_change_load(variable_dict)
+        # Ensure the heading is rebuilt with kwargs after generic display-load restores
+        # the raw heading token text.
+        self.update_heading_text(
+            "general.clan", text_kwargs={"name": game.clan.displayname}
+        )
 
         for key, value in variable_dict.items():
             try:
@@ -935,6 +942,9 @@ class PatrolScreen(Screens):
 
     def run_patrol_proceed(self, user_input):
         """Proceeds the patrol - to be run in the separate thread."""
+        # Patrol resolution changes save data/state, so mark save as outdated.
+        switch_set_value(Switch.saved_clan, False)
+
         if user_input in ["nopro", "notproceed"]:
             (
                 self.display_text,


### PR DESCRIPTION
### Motivation

- Fix a mismatch between the saved patrol clan identifier and the in-memory clan identity so resumed patrols are correctly recognized across locales. 
- Ensure the screen heading is correctly rebuilt after a generic display-load restores the raw heading token. 
- Mark the saved clan state as outdated when a patrol is resolved so the game knows to persist changes.

### Description

- Save the raw clan name under `patrol_clan_name` instead of the localized `clan_name` in `display_change_save`. 
- Compare `in_progress_data` using `patrol_clan_name` (falling back to `clan_name`) against `game.clan.name` in `screen_switches` so resumed patrols match the actual clan. 
- After `display_change_load`, call `update_heading_text` to rebuild the heading with `text_kwargs` so the displayed heading is correct. 
- Mark saves as outdated by calling `switch_set_value(Switch.saved_clan, False)` at the start of `run_patrol_proceed` because patrol resolution mutates clan state.

### Testing

- Ran the project's automated test suite (`pytest`) and observed no regressions or failing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bb13a5104832c83e19845f4c35315)