### PR TITLE
Guard sibling relationship checks when inheritance is absent

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2129,6 +2129,8 @@ class Cat:
 
     def is_half_sibling(self, other_cat: Cat):
         """Check if the cats are half siblings."""
+        if not self.inheritance or not self.inheritance.siblings:
+            return False
         if other_cat.ID not in self.inheritance.siblings.keys():
             return False
         half_siblings = [
@@ -2140,6 +2142,8 @@ class Cat:
 
     def is_adoptive_sibling(self, other_cat: Cat):
         """Check if the cats are adoptive siblings."""
+        if not self.inheritance or not self.inheritance.siblings:
+            return False
         if other_cat.ID not in self.inheritance.siblings.keys():
             return False
         adoptive_siblings = [


### PR DESCRIPTION
### Motivation
- Prevent an `AttributeError` when `self.inheritance` is `None` or lacks `siblings` data during sibling-related checks invoked by the relationship UI.

### Description
- Add defensive early returns in `Cat.is_half_sibling` and `Cat.is_adoptive_sibling` to return `False` when `self.inheritance` is falsy or `self.inheritance.siblings` is missing.

### Testing
- Ran `python -m compileall scripts/cat/cats.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f495c7bc4832c8bec25aba62672d7)