### PR TITLE
Fix patrol EXP assignment when cat experience is unset

### DIFF
--- a/scripts/events_module/patrol/patrol_outcome.py
+++ b/scripts/events_module/patrol/patrol_outcome.py
@@ -502,10 +502,11 @@ class PatrolOutcome:
 
         if gained_exp or app_exp:
             for cat in patrol.patrol_cats:
+                current_exp = cat.experience if cat.experience is not None else 0
                 if cat.status.rank.is_any_apprentice_rank():
-                    cat.experience = cat.experience + app_exp
+                    cat.experience = current_exp + app_exp
                 else:
-                    cat.experience = cat.experience + gained_exp
+                    cat.experience = current_exp + gained_exp
 
         return ""
 


### PR DESCRIPTION
### Motivation
- Prevent a `TypeError` when adding EXP to a cat whose `experience` field is `None` by normalizing missing experience to zero.

### Description
- In `scripts/events_module/patrol/patrol_outcome.py` initialize `current_exp = cat.experience if cat.experience is not None else 0` and use `current_exp` when adding `app_exp` or `gained_exp` for apprentice and non-apprentice cats respectively.

### Testing
- Ran `python -m compileall scripts/events_module/patrol/patrol_outcome.py` and it compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f6432232c832c8769a78cef522e4f)