### PR TITLE
Treat tattletail murder_reveal as clan-wide and adjust aware_individuals

### DIFF
--- a/scripts/events_module/short/short_event.py
+++ b/scripts/events_module/short/short_event.py
@@ -320,11 +320,14 @@ class ShortEvent:
 
         # handle murder reveals
         if "murder_reveal" in self.sub_type or "hidden_murder_reveal" in self.sub_type:
+            is_tattletail_reveal = "tattletail" in self.event_id
+            clan_reveal = "clan_wide" in self.tags or is_tattletail_reveal
+            aware_individuals = [] if clan_reveal else [self.random_cat.ID]
             self.main_cat.history.reveal_murder(
                 victim=self.victim_cat,
                 murderer_id=self.main_cat.ID,
-                clan_reveal="clan_wide" in self.tags,
-                aware_individuals=[self.random_cat.ID],
+                clan_reveal=clan_reveal,
+                aware_individuals=aware_individuals,
             )
             murderer_mates = []
             for mate_id in self.main_cat.mate:


### PR DESCRIPTION
### Motivation
- Ensure `murder_reveal` events triggered by tattletail-style events are treated as clan-wide reveals and do not incorrectly attribute a single aware individual.

### Description
- Detect `tattletail` in `self.event_id`, set `clan_reveal` when either `"clan_wide"` is in `self.tags` or the event is tattletail, and pass an empty `aware_individuals` list for clan-wide reveals while preserving the previous per-individual behavior otherwise.

### Testing
- No automated tests were run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1373e4debc832c94a6d7144baf9258)