### PR TITLE
Fix expanded mode config lookups

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -2331,7 +2331,7 @@ def handle_injuries_or_general_death(cat):
     path = (
         "death_related.classic_death_chance"
         if game.clan.game_mode == "classic"
-        else "death_related.death_chance"
+        else "death_related.expanded_death_chance"
     )
     death_chance = get_config(game.clan, path) - (
         get_config(game.clan, "death_related.war_death_modifier")

--- a/scripts/events_module/patrol/patrol.py
+++ b/scripts/events_module/patrol/patrol.py
@@ -951,7 +951,7 @@ class Patrol:
         path = (
             "patrol_generation.classic_difficulty_modifier"
             if game.clan.game_mode == "classic"
-            else "patrol_generation.difficulty_modifier"
+            else "patrol_generation.expanded_difficulty_modifier"
         )
 
         gm_modifier = get_config(game.clan, path)

--- a/scripts/events_module/short/condition_events.py
+++ b/scripts/events_module/short/condition_events.py
@@ -276,7 +276,7 @@ class Condition_Events:
             path = (
                 "condition_related.classic_illness_chance"
                 if game.clan.game_mode == "classic"
-                else "condition_related.illness_chance"
+                else "condition_related.expanded_illness_chance"
             )
             random_number = int(random.random() * get_config(game.clan, path))
             if (
@@ -357,7 +357,7 @@ class Condition_Events:
         path = (
             "condition_related.classic_injury_chance"
             if game.clan.game_mode == "classic"
-            else "condition_related.injury_chance"
+            else "condition_related.expanded_injury_chance"
         )
 
         injury_chance = get_config(game.clan, path) - (


### PR DESCRIPTION
### Motivation
- Prevent `KeyError` and incorrect behavior when `game.clan.game_mode` is not `classic` by using the correct expanded-mode config keys that actually exist in `resources/game_config.toml`.
- Align runtime lookups with the config naming convention to avoid missing-key crashes during death, condition, and patrol calculations.

### Description
- Use `death_related.expanded_death_chance` for non-`classic` general death rolls in `scripts/events.py` instead of the missing key `death_related.death_chance`.
- Use `condition_related.expanded_illness_chance` for non-`classic` illness rolls in `scripts/events_module/short/condition_events.py`.
- Use `condition_related.expanded_injury_chance` for non-`classic` injury rolls in `scripts/events_module/short/condition_events.py`.
- Use `patrol_generation.expanded_difficulty_modifier` for non-`classic` patrol difficulty lookups in `scripts/events_module/patrol/patrol.py`.

### Testing
- Compiled the modified modules with `python -m py_compile scripts/events.py scripts/events_module/short/condition_events.py scripts/events_module/patrol/patrol.py`, which succeeded.
- Verified the referenced config keys exist by reading `resources/game_config.toml` with a small `tomllib` check script, which printed expected values for the used keys.
- Running `python -m pytest tests/test_events.py -q` was blocked during collection due to a missing test-environment dependency (`ujson`), so full test execution was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19d995cab8832c9340d9e553154460)