### PR TITLE
Fix initial half sibling relationship labels

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -2131,29 +2131,11 @@ class Cat:
 
     def is_half_sibling(self, other_cat: Cat):
         """Check if the cats are half siblings."""
-        if not self.inheritance or not self.inheritance.siblings:
-            return False
-        if other_cat.ID not in self.inheritance.siblings.keys():
-            return False
-        half_siblings = [
-            key
-            for key, value in self.inheritance.siblings.items()
-            if "half sibling" in value["additional"]
-        ]
-        return other_cat.ID in half_siblings
+        return inheritance_db.is_half_sibling(self.ID, other_cat.ID)
 
     def is_adoptive_sibling(self, other_cat: Cat):
         """Check if the cats are adoptive siblings."""
-        if not self.inheritance or not self.inheritance.siblings:
-            return False
-        if other_cat.ID not in self.inheritance.siblings.keys():
-            return False
-        adoptive_siblings = [
-            key
-            for key, value in self.inheritance.siblings.items()
-            if "adoptive" in value["additional"]
-        ]
-        return other_cat.ID in adoptive_siblings
+        return inheritance_db.is_adoptive_sibling(self.ID, other_cat.ID)
     
     def is_uncle_aunt(self, other_cat: Cat):
         """Check if the cats are related as uncle/aunt and niece/nephew."""

--- a/scripts/cat_relations/inheritance2.py
+++ b/scripts/cat_relations/inheritance2.py
@@ -120,6 +120,15 @@ class InheritanceDb:
             for cat_id, saved_family_rel in self._saved_family_rels.items():
                 self._cat_to_rels[cat_id] = saved_family_rel
 
+    def _get_parents_by_relation_type(
+        self, cat_id: str, relation_type: RelationType
+    ) -> Set[str]:
+        return {
+            p["cat_id"]
+            for p in self._cat_to_rels[cat_id].parents
+            if p["relation_type"] == relation_type
+        }
+
     def get_parents(self, cat_id: str) -> Set[str]:
         return {p["cat_id"] for p in self._cat_to_rels[cat_id].parents}
 
@@ -215,6 +224,41 @@ class InheritanceDb:
 
     def is_sibling(self, cat_a: str, cat_b: str) -> bool:
         return cat_b in self.get_siblings(cat_a)
+
+    def is_half_sibling(self, cat_a: str, cat_b: str) -> bool:
+        """Check if cats share exactly one blood parent while at least one has two."""
+        cat_a_blood_parents = self._get_parents_by_relation_type(
+            cat_a, RelationType.BLOOD
+        )
+        cat_b_blood_parents = self._get_parents_by_relation_type(
+            cat_b, RelationType.BLOOD
+        )
+
+        return len(cat_a_blood_parents & cat_b_blood_parents) == 1 and (
+            len(cat_a_blood_parents) > 1 or len(cat_b_blood_parents) > 1
+        )
+
+    def is_adoptive_sibling(self, cat_a: str, cat_b: str) -> bool:
+        """Check if cats are siblings through at least one adoptive parent."""
+        cat_a_adoptive_parents = self._get_parents_by_relation_type(
+            cat_a, RelationType.ADOPTIVE
+        )
+        cat_b_adoptive_parents = self._get_parents_by_relation_type(
+            cat_b, RelationType.ADOPTIVE
+        )
+        cat_a_blood_parents = self._get_parents_by_relation_type(
+            cat_a, RelationType.BLOOD
+        )
+        cat_b_blood_parents = self._get_parents_by_relation_type(
+            cat_b, RelationType.BLOOD
+        )
+
+        blood_overlap = cat_a_blood_parents & cat_b_blood_parents
+        adoptive_overlap = cat_a_adoptive_parents & cat_b_adoptive_parents
+        adoptive_overlap |= cat_a_blood_parents & cat_b_adoptive_parents
+        adoptive_overlap |= cat_a_adoptive_parents & cat_b_blood_parents
+
+        return not blood_overlap and bool(adoptive_overlap)
 
     def is_uncle_aunt(self, maybe_uncle_aunt: str, cat_a: str) -> bool:
         return cat_a in self.get_siblings_children(maybe_uncle_aunt)

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -67,6 +67,34 @@ class TestRelativesFunction(unittest.TestCase):
         self.assertTrue(kit2.is_sibling(kit1))
         self.assertTrue(kit1.is_sibling(kit2))
 
+    def test_is_half_sibling_without_legacy_inheritance(self):
+        shared_parent = Cat(disable_random=True)
+        other_parent1 = Cat(disable_random=True)
+        other_parent2 = Cat(disable_random=True)
+        kit1 = Cat(
+            parent1=shared_parent.ID, parent2=other_parent1.ID, disable_random=True
+        )
+        kit2 = Cat(
+            parent1=shared_parent.ID, parent2=other_parent2.ID, disable_random=True
+        )
+        inheritance_db.load_inheritances(Cat)
+
+        self.assertIsNone(kit1.inheritance)
+        self.assertIsNone(kit2.inheritance)
+        self.assertTrue(kit1.is_sibling(kit2))
+        self.assertTrue(kit1.is_half_sibling(kit2))
+        self.assertTrue(kit2.is_half_sibling(kit1))
+
+    def test_shared_single_parent_siblings_are_not_half_siblings(self):
+        shared_parent = Cat(disable_random=True)
+        kit1 = Cat(parent1=shared_parent.ID, disable_random=True)
+        kit2 = Cat(parent1=shared_parent.ID, disable_random=True)
+        inheritance_db.load_inheritances(Cat)
+
+        self.assertTrue(kit1.is_sibling(kit2))
+        self.assertFalse(kit1.is_half_sibling(kit2))
+        self.assertFalse(kit2.is_half_sibling(kit1))
+
     # test that is_uncle_aunt returns True for a uncle/aunt-cat relationship and False otherwise
     def test_is_uncle_aunt(self):
         grand_parent = Cat(disable_random=True)


### PR DESCRIPTION
### Motivation
- The relationship UI was showing sibling types incorrectly on first view because it relied on per-cat `Inheritance` data that isn't initialized until the family tree is built, causing half-sibling/adoptive labels to be wrong until a later action.
- The goal is to have the relationship screen load the correct relation type immediately from the centralized inheritance DB.

### Description
- Updated `Cat.is_half_sibling()` and `Cat.is_adoptive_sibling()` to delegate to the global `inheritance_db` instead of depending on per-cat `Inheritance` objects so relation checks work before legacy per-cat inheritance is created (`scripts/cat/cats.py`).
- Added `_get_parents_by_relation_type()` and new `is_half_sibling()`/`is_adoptive_sibling()` helpers to `InheritanceDb` to detect half-blood and adoptive sibling relationships using the loaded DB, preserving prior classification rules and ensuring blood/adoptive overlaps are handled (`scripts/cat_relations/inheritance2.py`).
- Adjusted adoptive-sibling logic to avoid mislabeling when blood overlap exists (requires no blood overlap for adoptive-only classification).
- Added regression tests to `tests/test_cat.py` to cover half-sibling detection when legacy per-cat inheritance is not present, and to ensure shared-single-parent siblings are not marked half-siblings.

### Testing
- Ran a focused runtime check using a short `python` snippet that built a fake cat list, invoked `inheritance_db.load_inheritances(...)`, and asserted `is_half_sibling()` behavior; this check passed.
- Verified files compile with `python -m py_compile scripts/cat_relations/inheritance2.py scripts/cat/cats.py tests/test_cat.py`, which succeeded.
- Attempted `pytest` for the modified relatives tests (`tests/test_cat.py::TestRelativesFunction`), but the run could not execute in this environment due to a missing `pygame` dependency, so the full test run was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e21273fa8832ca93b31e8e30ce07a)