### PR TITLE
Fix herb gathering focus storage timing

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -268,8 +268,6 @@ def one_moon():
             game.cur_events_list.insert(0, Single_Event(event_string))
             game.freshkill_event_list.append(event_string)
 
-    handle_focus()
-
     # handle the herb supply for the moon
     game.clan.herb_supply.handle_moon(
         clan_size=get_living_clan_cat_count(Cat),
@@ -280,6 +278,11 @@ def one_moon():
             working=True,
         ),
     )
+
+    # Handle Clan focus after the normal herb moonskip so herbs gathered by the
+    # herb-gathering focus are not immediately spent on this moon's treatments
+    # or expired before the player can see them in the med den stores.
+    handle_focus()
 
     if game.clan.game_mode in ("expanded", "cruel_season"):
         amount_per_med = get_amount_cat_for_one_medic(game.clan)

--- a/tests/test_herb_focus.py
+++ b/tests/test_herb_focus.py
@@ -1,0 +1,45 @@
+import inspect
+import os
+import unittest
+from types import SimpleNamespace
+
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"
+
+from scripts import events
+from scripts.clan_resources.herb.herb_supply import HerbSupply
+from scripts.game_structure import game
+
+
+class TestHerbGatheringFocus(unittest.TestCase):
+    def test_focus_herbs_are_collected_for_med_den_stores(self):
+        """The focus message should correspond to herbs actually added to stores."""
+        herb_supply = HerbSupply()
+        original_clan = game.clan
+        original_get_found_herbs = herb_supply.get_found_herbs
+
+        try:
+            game.clan = SimpleNamespace(herb_supply=herb_supply)
+
+            def fake_get_found_herbs(*_args, **_kwargs):
+                herb_supply.add_herb("juniper", 3)
+                return ["3 juniper bunches"], {"juniper": 3}
+
+            herb_supply.get_found_herbs = fake_get_found_herbs
+
+            herb_supply.handle_focus([object()], assistants=[object()])
+
+            self.assertEqual(herb_supply.collected["juniper"], 3)
+            self.assertEqual(herb_supply.total_of_herb("juniper"), 3)
+        finally:
+            herb_supply.get_found_herbs = original_get_found_herbs
+            game.clan = original_clan
+
+    def test_moonskip_handles_normal_herb_cycle_before_focus(self):
+        """Focus herbs should not be spent by the same moon's treatment pass."""
+        source = inspect.getsource(events.one_moon)
+
+        self.assertLess(
+            source.index("game.clan.herb_supply.handle_moon"),
+            source.index("handle_focus()"),
+        )


### PR DESCRIPTION
### Motivation
- Herb-gathering focus herbs were sometimes not visible in the med den because they were gathered before the moon's normal herb cycle and could be spent or expired in the same moon. 
- Ensure herbs gathered by the "assisting with herb gathering" focus are actually added to the med den stores and persist for the player to see.

### Description
- Move Clan focus handling to after the normal herb moonskip cycle in `one_moon()` so `game.clan.herb_supply.handle_moon(...)` runs before `handle_focus()` in `scripts/events.py`.
- Add a unit test `tests/test_herb_focus.py` that stubs `get_found_herbs` to assert focus-gathered herbs are added to `HerbSupply.collected` and that `handle_moon` appears before `handle_focus` in `one_moon()`.

### Testing
- Ran the new unit tests with `uv run python -m pytest tests/test_herb_focus.py -q` and received `2 passed` for the added tests.
- Attempted to run the same tests with `python -m pytest tests/test_herb_focus.py`, but test collection failed in that environment due to a missing `pygame` dependency (import error), which is an environment setup issue and not a failure of the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f49869670832cbad99cebe0815583)