### PR TITLE
Use dedicated name sort keys for Cat sorting and add tests

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -3554,6 +3554,14 @@ class Cat:
     # ---------------------------------------------------------------------------- #
 
     @staticmethod
+    def name_sort_key(cat: Cat):
+        return cat.name.prefix.lower()
+
+    @staticmethod
+    def reverse_name_sort_key(cat: Cat):
+        return tuple(-ord(char) for char in cat.name.prefix.lower()) + (0,)
+
+    @staticmethod
     def sort_cats(given_list=None):
         # disable unnecessary lambda in this function
         # pylint: disable=unnecessary-lambda
@@ -3579,9 +3587,9 @@ class Cat:
         elif sort_type == "death":
             given_list.sort(key=lambda x: -1 * int(x.dead_for))
         elif sort_type == "name":
-            given_list.sort(key=lambda x: x.name.prefix.lower())
+            given_list.sort(key=lambda x: Cat.name_sort_key(x))
         elif sort_type == "reverse_name":
-            given_list.sort(key=lambda x: x.name.prefix.lower(), reverse=True)
+            given_list.sort(key=lambda x: Cat.name_sort_key(x), reverse=True)
 
         return
 
@@ -3615,10 +3623,10 @@ class Cat:
             elif sort_type == "death":
                 bisect.insort(Cat.all_cats_list, c, key=lambda x: -1 * int(x.dead_for))
             elif sort_type == "name":
-                bisect.insort(Cat.all_cats_list, c, key=lambda x: int(x.name.prefix))
+                bisect.insort(Cat.all_cats_list, c, key=lambda x: Cat.name_sort_key(x))
             elif sort_type == "reverse_name":
                 bisect.insort(
-                    Cat.all_cats_list, c, key=lambda x: -1 * int(x.name.prefix)
+                    Cat.all_cats_list, c, key=lambda x: Cat.reverse_name_sort_key(x)
                 )
         except (TypeError, NameError):
             # If you are using python 3.8, key is not a supported parameter into insort. Therefore, we'll need to

--- a/tests/test_cat_sorting.py
+++ b/tests/test_cat_sorting.py
@@ -1,0 +1,47 @@
+from types import SimpleNamespace
+
+from scripts.cat.cats import Cat
+from scripts.game_structure.game.switches import Switch, switch_get_value, switch_set_value
+
+
+def make_cat(prefix):
+    return SimpleNamespace(name=SimpleNamespace(prefix=prefix))
+
+
+def test_insert_cat_sorts_names_alphabetically():
+    original_cats = Cat.all_cats_list
+    original_sort_type = switch_get_value(Switch.sort_type)
+    Cat.all_cats_list = [make_cat("Bramble"), make_cat("Dawn")]
+    switch_set_value(Switch.sort_type, "name")
+
+    try:
+        Cat.insert_cat(make_cat("Crested"))
+
+        assert [cat.name.prefix for cat in Cat.all_cats_list] == [
+            "Bramble",
+            "Crested",
+            "Dawn",
+        ]
+    finally:
+        Cat.all_cats_list = original_cats
+        switch_set_value(Switch.sort_type, original_sort_type)
+
+
+def test_insert_cat_sorts_names_reverse_alphabetically():
+    original_cats = Cat.all_cats_list
+    original_sort_type = switch_get_value(Switch.sort_type)
+    Cat.all_cats_list = [make_cat("Dawn"), make_cat("Crest"), make_cat("Bramble")]
+    switch_set_value(Switch.sort_type, "reverse_name")
+
+    try:
+        Cat.insert_cat(make_cat("Crested"))
+
+        assert [cat.name.prefix for cat in Cat.all_cats_list] == [
+            "Dawn",
+            "Crested",
+            "Crest",
+            "Bramble",
+        ]
+    finally:
+        Cat.all_cats_list = original_cats
+        switch_set_value(Switch.sort_type, original_sort_type)


### PR DESCRIPTION
### Motivation
- Fix incorrect name-based sorting logic that previously attempted to cast name prefixes to integers and used inline lambdas, which caused errors and inconsistent behavior when inserting with `bisect.insort`.
- Provide a reliable reverse-name sort key that works with `bisect` and preserves case-insensitive alphabetical ordering.

### Description
- Added two static helper methods on `Cat`: `name_sort_key` which returns `cat.name.prefix.lower()` and `reverse_name_sort_key` which returns a tuple of negated character codes to represent reverse alphabetical order.
- Replaced ad-hoc lambdas and unsafe `int()` casts in `Cat.sort_cats` and `Cat.insert_cat` with calls to `Cat.name_sort_key` and `Cat.reverse_name_sort_key` to standardize name sorting behavior.
- Added unit tests in `tests/test_cat_sorting.py` that exercise alphabetical and reverse-alphabetical insertion when `Switch.sort_type` is set to `name` and `reverse_name` respectively.

### Testing
- Added `tests/test_cat_sorting.py` containing `test_insert_cat_sorts_names_alphabetically` and `test_insert_cat_sorts_names_reverse_alphabetically` which manipulate `Cat.all_cats_list` and `Switch.sort_type` and restore state in `finally` blocks.
- Ran the new tests and they passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35b7af4b0c832cb70b29cc79cc7734)