### PR TITLE
Fix patrol screen resume clan lookup

### DIFF
--- a/scripts/screens/PatrolScreen.py
+++ b/scripts/screens/PatrolScreen.py
@@ -307,10 +307,18 @@ class PatrolScreen(Screens):
     def screen_switches(self):
         super().screen_switches()
 
+        saved_clan_name = None
+        saved_moon = None
+        if self.in_progress_data is not None:
+            saved_clan_name = self.in_progress_data.get(
+                "patrol_clan_name", self.in_progress_data.get("clan_name")
+            )
+            saved_moon = self.in_progress_data.get("current_moon")
+
         if (
             self.in_progress_data is not None
-            and self.in_progress_data["current_moon"] == game.clan.age
-            and self.in_progress_data["clan_name"] == game.clan.name
+            and saved_moon == game.clan.age
+            and saved_clan_name == game.clan.name
         ):
             self.display_change_load(self.in_progress_data)
         else:


### PR DESCRIPTION
### Motivation
- Prevent a `KeyError` when resuming an in-progress patrol by handling saved state that may use either the newer `patrol_clan_name` key or the older `clan_name` key and by validating the saved moon before restoring.

### Description
- Update `scripts/screens/PatrolScreen.py` to read `patrol_clan_name` with a fallback to `clan_name` and to read `current_moon` into local `saved_clan_name`/`saved_moon` variables, then compare those safe values to the current clan and moon before calling `display_change_load`.

### Testing
- Ran `python -m py_compile scripts/screens/PatrolScreen.py`, which succeeded.
- Ran `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a397c407fc0832cb9b04c1bf7144614)