### PR TITLE
PatrolScreen: support legacy save keys and simplify heading update

### DIFF
--- a/scripts/screens/PatrolScreen.py
+++ b/scripts/screens/PatrolScreen.py
@@ -307,10 +307,18 @@ class PatrolScreen(Screens):
     def screen_switches(self):
         super().screen_switches()
 
+        saved_clan_name = None
+        saved_moon = None
+        if self.in_progress_data is not None:
+            saved_clan_name = self.in_progress_data.get(
+                "patrol_clan_name", self.in_progress_data.get("clan_name")
+            )
+            saved_moon = self.in_progress_data.get("current_moon")
+
         if (
             self.in_progress_data is not None
-            and self.in_progress_data["current_moon"] == game.clan.age
-            and self.in_progress_data["clan_name"] == game.clan.name
+            and saved_moon == game.clan.age
+            and saved_clan_name == game.clan.name
         ):
             self.display_change_load(self.in_progress_data)
         else:
@@ -318,7 +326,7 @@ class PatrolScreen(Screens):
             self.open_choose_cats_screen()
 
         self.set_disabled_menu_buttons(["patrols"])
-        self.update_heading_text("general.clan", text_kwargs={"name": game.clan.name})
+        self.update_heading_text(game.clan.name)
         self.show_mute_buttons()
         self.show_menu_buttons()
 
@@ -356,11 +364,9 @@ class PatrolScreen(Screens):
 
     def display_change_load(self, variable_dict: Dict):
         super().display_change_load(variable_dict)
-        # Ensure the heading is rebuilt with kwargs after generic display-load restores
+        # Ensure the heading is rebuilt after generic display-load restores
         # the raw heading token text.
-        self.update_heading_text(
-            "general.clan", text_kwargs={"name": game.clan.name}
-        )
+        self.update_heading_text(game.clan.name)
 
         for key, value in variable_dict.items():
             try:


### PR DESCRIPTION
### Motivation

- Allow `PatrolScreen` to correctly restore in-progress patrols when saved state uses either the new or legacy key names for clan and moon.
- Simplify how the screen heading is updated by passing the clan name directly to `update_heading_text` instead of using a token+kwargs pattern.

### Description

- Added local `saved_clan_name` and `saved_moon` lookups that prefer `patrol_clan_name` and fall back to the older `clan_name` key when restoring `in_progress_data` in `screen_switches`.
- Updated the in-progress check in `screen_switches` to compare `saved_moon` and `saved_clan_name` against `game.clan.age` and `game.clan.name` respectively.
- Replaced calls to `update_heading_text("general.clan", text_kwargs={"name": ...})` with direct calls to `update_heading_text(game.clan.name)` and adjusted the related comment.
- Left `display_change_save` to continue writing `current_moon` and `patrol_clan_name` to saved state for the new format.

### Testing

- Ran the automated test suite with `pytest` and the tests covering screen load/save behavior passed.
- Ran the project's linter (`flake8`) and there were no new linting errors.
- Exercised the patrol screen restore paths in automated UI/integration smoke tests which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a397c407fc0832cb9b04c1bf7144614)