### PR TITLE
Remove rejected coparent-kit relationships on negative unmated births

### DIFF
--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -1072,6 +1072,11 @@ class Pregnancy_Events:
             and not other_cat.dead
             and coparenting_outcome
         ):
+            if coparenting_outcome == "negative":
+                for kit in kits:
+                    other_cat.relationships.pop(kit.ID, None)
+                    kit.relationships.pop(other_cat.ID, None)
+
             for first_cat, second_cat in ((cat, other_cat), (other_cat, cat)):
                 rel = first_cat.relationships.get(second_cat.ID)
                 if not rel:


### PR DESCRIPTION
### Motivation
- Ensure that when unmated co-parenting results in a negative outcome, the second parent and the newborn kits have no relationship entries toward each other to reflect rejection.

### Description
- Add logic in `scripts/events_module/relationship/pregnancy_events.py` to remove relationship entries between `other_cat` and each `kit` when `coparenting_outcome == "negative"`, executed before parent-parent relationship adjustments.

### Testing
- Ran `python -m py_compile scripts/events_module/relationship/pregnancy_events.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c4cc719b0832c829d3e56f1fc22c7)