### PR TITLE
Fix clan placeholder replacement in war event text

### DIFF
--- a/scripts/events_module/text_adjust.py
+++ b/scripts/events_module/text_adjust.py
@@ -260,6 +260,7 @@ def get_special_snippet_list(
     else:
         return final_snippets
 
+
 def find_special_list_types(text):
     """
     purely to identify which senses are being called for by a snippet abbreviation
@@ -518,12 +519,22 @@ def event_text_adjust(
         text = text.replace("multi_cat", list_text)
 
     # other_clan_name
-    if "o_c_n" in text and other_clan:
-        text = _replace_clan_name(
-            text,
-            "o_c_n",
-            other_clan if isinstance(other_clan, str) else other_clan.name,
-        )
+    if "o_c_n" in text:
+        if other_clan:
+            other_clan_name = (
+                other_clan if isinstance(other_clan, str) else other_clan.name
+            )
+        else:
+            # War short events should always be called with the enemy clan, but
+            # older call paths or saves may not have that context. Fall back to
+            # the current war enemy instead of letting the later c_n replacement
+            # turn o_c_n into strings like o_BridgeClan.
+            other_clan_name = getattr(getattr(game, "clan", None), "war", {}).get(
+                "enemy"
+            )
+
+        if other_clan_name:
+            text = _replace_clan_name(text, "o_c_n", other_clan_name)
 
     # clan_name
     if "c_n" in text:
@@ -597,7 +608,11 @@ def _replace_clan_name(text, abbreviation, clan_name):
                     text = " ".join(modify)
                     break
 
-    return text.replace(abbreviation, clan_name)
+    return re.sub(
+        rf"(?<![A-Za-z0-9_]){re.escape(abbreviation)}(?![A-Za-z0-9_])",
+        str(clan_name),
+        text,
+    )
 
 
 def leader_ceremony_text_adjust(

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -13,7 +13,7 @@ from scripts.game_structure.localization import (
     set_lang_config_directory,
 )
 from scripts.cat.pronouns import get_new_pronouns, determine_plural_pronouns
-from scripts.events_module.text_adjust import event_text_adjust
+from scripts.events_module.text_adjust import event_text_adjust, _replace_clan_name
 
 
 class TestLocalisation(unittest.TestCase):
@@ -50,6 +50,26 @@ class TestLocalisation(unittest.TestCase):
     def tearDown(self):
         i18n.config.set("locale", "en")
         set_lang_config_directory("resources/lang/en/config.json")
+
+    def test_clan_name_replacement_does_not_replace_embedded_placeholder(self):
+        text = "m_c is eager to sink his claws into o_c_n during the next skirmish."
+
+        self.assertEqual(
+            _replace_clan_name(text, "c_n", "BridgeClan"),
+            text,
+        )
+
+    def test_clan_name_replacement_preserves_full_placeholder(self):
+        text = "A o_c_n patrol fought c_n's patrol."
+
+        self.assertEqual(
+            _replace_clan_name(text, "o_c_n", "ShadowClan"),
+            "A ShadowClan patrol fought c_n's patrol.",
+        )
+        self.assertEqual(
+            _replace_clan_name(text, "c_n", "BridgeClan"),
+            "A o_c_n patrol fought BridgeClan's patrol.",
+        )
 
     def test_get_singular_pronouns(self):
         for i, gender in enumerate(["nonbinary", "male", "female"]):


### PR DESCRIPTION
### Motivation
- Prevent placeholder replacements from colliding so that `o_c_n` (other clan) is not accidentally transformed into things like `o_BridgeClan` when `c_n` is also replaced. 
- Ensure war-related short events still resolve `o_c_n` even when an explicit OtherClan object is not provided by falling back to the current war enemy.

### Description
- Adjusted `event_text_adjust` so `o_c_n` is replaced using an explicit `other_clan` when available and otherwise falls back to `game.clan.war["enemy"]` before `c_n` replacement runs. 
- Tightened `_replace_clan_name` to use a regex that only replaces standalone placeholders (avoiding replacements embedded inside other tokens such as `o_c_n`).
- Added unit tests to `tests/test_lang.py` validating that `c_n` replacement does not replace embedded placeholders and that `o_c_n`/`c_n` replacements behave as expected.

### Testing
- Ran localization unit tests with the project environment using `uv run python -m unittest tests/test_lang.py`, and the tests passed (`Ran 6 tests ... OK`).
- `pytest` run directly failed during collection due to a missing system environment dependency (`i18n`) outside this change, so tests are exercised via the repository `uv` workflow instead. 
- Ran formatting checks with `uv run black --check` and applied `black` reformatting where required, and `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ec12bb944832c8d6e1e5525b034fc)