### PR TITLE
Fix pair relationship event constraints and same-sex romance gating

### DIFF
--- a/scripts/events_module/relationship/generate_pair_event.py
+++ b/scripts/events_module/relationship/generate_pair_event.py
@@ -23,7 +23,6 @@ from scripts.events_module.text_pool_event import TextPoolEvent
 from scripts.game_structure import game
 from scripts.game_structure.localization import load_lang_resource
 from scripts.events_module.relationship.romance_chance import (
-    cats_are_same_sex,
     passes_same_sex_romance_chance,
 )
 
@@ -187,8 +186,9 @@ def _get_type_of_interaction(
         # if a romance relationship is not possible, remove this type, but only if there are no mates
         # if there already mates (set up by the user for example), don't remove this type
         mate_from_to = main_cat.is_potential_mate(other_cat, for_love_interest=True)
-        mate_to_from = main_cat.is_potential_mate(other_cat, for_love_interest=True)
-        if not mate_from_to or not mate_to_from:
+        mate_to_from = other_cat.is_potential_mate(main_cat, for_love_interest=True)
+        same_sex_romance_allowed = passes_same_sex_romance_chance(main_cat, other_cat)
+        if not mate_from_to or not mate_to_from or not same_sex_romance_allowed:
             while RelType.ROMANCE in value_weights:
                 value_weights.pop(RelType.ROMANCE)
 
@@ -210,7 +210,7 @@ def _get_type_of_interaction(
 
 def _get_event(
     events: list[TextPoolEvent], main_cat: Cat, other_cat: Cat
-) -> TextPoolEvent:
+) -> Optional[TextPoolEvent]:
     """
     Returns a valid event for all involved cats
     :param events: The list of events to filter
@@ -248,13 +248,14 @@ def _get_event(
     ]
 
     for e in possible_events:
-        for constraint in e.relationship_constraint:
-            if not check_rel_constraint_groups(
-                constraint, {"m_c": main_cat, "r_c": other_cat}
-            ):
-                continue
+        if all(
+            check_rel_constraint_groups(constraint, {"m_c": main_cat, "r_c": other_cat})
+            for constraint in e.relationship_constraint
+        ):
+            final_events.append(e)
 
-        final_events.append(e)
+    if not final_events:
+        return None
 
     return choice(final_events)
 
@@ -364,7 +365,14 @@ def _apply_extra_influence(
         # find the values and their amounts for the kwargs
         value_changes = {}
         for value in change["values"]:
+            if value == RelType.ROMANCE and not _passes_romance_change_chance(
+                cats_from, cats_to
+            ):
+                continue
             value_changes[value] = change["amount"]
+
+        if not value_changes:
+            continue
 
         # change the relationship!
         # only apply log if this is a change to r_c's feelings, cus m_c will already have the event in their log, and we don't want to double it
@@ -374,6 +382,15 @@ def _apply_extra_influence(
             **value_changes,
             log=chosen_string if involved_cats["r_c"] in cats_from else None,
         )
+
+
+def _passes_romance_change_chance(cats_from: list[Cat], cats_to: list[Cat]) -> bool:
+    """Return True if generated romance changes are allowed for every pair."""
+    return all(
+        passes_same_sex_romance_chance(cat_from, cat_to)
+        for cat_from in cats_from
+        for cat_to in cats_to
+    )
 
 
 def _apply_base_influence(
@@ -406,7 +423,9 @@ def _apply_base_influence(
         # and a positive interaction will affect all values to a positive degree
 
         if type_of_interaction == RelType.ROMANCE:
-            if not passes_same_sex_romance_chance:
+            if not passes_same_sex_romance_chance(
+                relationship.cat_from, relationship.cat_to
+            ):
                 amount = 0
             relationship.romance += amount
 
@@ -425,7 +444,9 @@ def _apply_base_influence(
     else:
         if (
             type_of_interaction == RelType.ROMANCE
-            and not passes_same_sex_romance_chance
+            and not passes_same_sex_romance_chance(
+                relationship.cat_from, relationship.cat_to
+            )
         ):
             return
         setattr(

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -663,3 +663,116 @@ class RomanceInteractionWeighting(unittest.TestCase):
         intact_romance_weight = intact_weights[intact_values.index(RelType.ROMANCE)]
 
         self.assertLess(mixed_romance_weight, intact_romance_weight)
+
+
+class PairEventConstraintRegression(unittest.TestCase):
+    def test_get_event_rejects_failed_relationship_constraint(self):
+        cat_from = Cat()
+        cat_to = Cat()
+        rel = Relationship(cat_from, cat_to)
+        rel.romance = 12
+        cat_from.relationships[cat_to.ID] = rel
+
+        constrained_event = TextPoolEvent(
+            id="requires_adores_not_mates",
+            strings=["test"],
+            relationship_constraint=[
+                {
+                    "cats_from": ["m_c"],
+                    "cats_to": ["r_c"],
+                    "mutual": False,
+                    "constraints": ["adores", "-mates"],
+                }
+            ],
+        )
+        fallback_event = TextPoolEvent(id="fallback", strings=["test"])
+
+        chosen_event = generate_pair_event._get_event(
+            events=[constrained_event, fallback_event],
+            main_cat=cat_from,
+            other_cat=cat_to,
+        )
+
+        self.assertEqual(chosen_event, fallback_event)
+
+    def test_get_event_returns_none_when_no_event_matches_constraints(self):
+        cat_from = Cat()
+        cat_to = Cat()
+
+        mates_only_event = TextPoolEvent(
+            id="mates_only",
+            strings=["test"],
+            relationship_constraint=[
+                {
+                    "cats_from": ["m_c"],
+                    "cats_to": ["r_c"],
+                    "mutual": False,
+                    "constraints": ["mates"],
+                }
+            ],
+        )
+
+        chosen_event = generate_pair_event._get_event(
+            events=[mates_only_event],
+            main_cat=cat_from,
+            other_cat=cat_to,
+        )
+
+        self.assertIsNone(chosen_event)
+
+    @patch(
+        "scripts.events_module.relationship.generate_pair_event._get_change_amount",
+        return_value=10,
+    )
+    @patch(
+        "scripts.events_module.relationship.generate_pair_event.passes_same_sex_romance_chance",
+        return_value=False,
+    )
+    def test_same_sex_base_romance_gain_is_blocked(
+        self, _mocked_chance, _mocked_amount
+    ):
+        cat_from = Cat(gender="female")
+        cat_to = Cat(gender="female")
+        relationship = Relationship(cat_from, cat_to)
+
+        generate_pair_event._apply_base_influence(
+            intensity="low",
+            relationship=relationship,
+            type_of_change="positive",
+            type_of_interaction=RelType.ROMANCE,
+            chosen_string="test",
+        )
+
+        self.assertEqual(relationship.romance, 0)
+
+    @patch(
+        "scripts.events_module.relationship.generate_pair_event.passes_same_sex_romance_chance",
+        return_value=False,
+    )
+    def test_same_sex_extra_romance_gain_is_blocked(self, _mocked_chance):
+        cat_from = Cat(gender="female")
+        cat_to = Cat(gender="female")
+        relationship = Relationship(cat_from, cat_to)
+        cat_from.relationships[cat_to.ID] = relationship
+        event = TextPoolEvent(
+            id="extra_romance",
+            strings=["test"],
+            relationship_changes=[
+                {
+                    "cats_from": ["m_c"],
+                    "cats_to": ["r_c"],
+                    "mutual": False,
+                    "values": ["romance"],
+                    "amount": 10,
+                }
+            ],
+        )
+
+        generate_pair_event._apply_extra_influence(
+            event=event,
+            involved_cats={"m_c": cat_from, "r_c": cat_to},
+            relationship=relationship,
+            chosen_string="test",
+        )
+
+        self.assertEqual(relationship.romance, 0)


### PR DESCRIPTION
### Motivation
- Relationship events were being selected even when their relationship constraint groups did not all pass, allowing inappropriate interactions like `adores` + `-mates` to trigger. 
- Same-sex romance generation and event-applied romance changes were not consistently subject to the shared same-sex romance chance gate, leading to unintended same-sex romance gains.

### Description
- Ensure a normal pair event is considered valid only when all of its `relationship_constraint` groups pass by using an `all(...)` check in `_get_event`, and return `None` when no events match. 
- Require potential-mate checks in both directions in `_get_type_of_interaction` and gate romance interaction availability with `passes_same_sex_romance_chance(...)`. 
- Add a helper `_passes_romance_change_chance` and skip event-defined romance changes in `_apply_extra_influence` when the same-sex romance gate fails. 
- Call `passes_same_sex_romance_chance(...)` correctly in `_apply_base_influence` for high- and low-intensity romance changes and update type hints (return `Optional[TextPoolEvent]`). 
- Add regression tests in `tests/test_interactions.py` (`PairEventConstraintRegression`) covering constraint rejection, returning `None` for no matches, and blocking same-sex romance gains for both base and extra influence paths.

### Testing
- Formatted changed files with `black` which succeeded. 
- Compiled `scripts/events_module/relationship/generate_pair_event.py` with `python -m py_compile` which succeeded. 
- Ran the targeted regression tests `pytest -q tests/test_interactions.py::PairEventConstraintRegression` which passed. 
- Running the full `tests/test_interactions.py` uncovers unrelated pre-existing failures (missing `SingleInteraction`, a `parent/child` assertion, and an invalid patch target) which are outside the scope of this change and therefore remain failing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a455d84db348333b5a94e63aadf5cd2)