### PR TITLE
Use explicit `family=True` when constructing Relationship objects in event code

### DIFF
--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -467,7 +467,7 @@ def create_new_cat_block(
                     continue
 
                 y = randrange(0, 20)
-                start_relation = Relationship(n_c, inter_cat, False, True)
+                start_relation = Relationship(n_c, inter_cat, family=True)
                 start_relation.like += 40 + y
                 start_relation.comfort = 40 + y
                 start_relation.respect = 10 + y
@@ -480,7 +480,7 @@ def create_new_cat_block(
                     continue
 
                 y = randrange(0, 20)
-                start_relation = Relationship(par, n_c, False, True)
+                start_relation = Relationship(par, n_c, family=True)
                 start_relation.like += 60 + y
                 start_relation.comfort = 40 + y
                 start_relation.respect = 30 + y
@@ -488,7 +488,7 @@ def create_new_cat_block(
                 par.relationships[n_c.ID] = start_relation
 
                 y = randrange(0, 20)
-                start_relation = Relationship(n_c, par, False, True)
+                start_relation = Relationship(n_c, par, family=True)
                 start_relation.like += 40 + y
                 start_relation.comfort = 70 + y
                 start_relation.respect = 30 + y
@@ -503,7 +503,7 @@ def create_new_cat_block(
                 par = Cat.fetch_cat(par)
 
                 y = randrange(0, 20)
-                start_relation = Relationship(par, n_c, False, True)
+                start_relation = Relationship(par, n_c, family=True)
                 start_relation.like += 60 + y
                 start_relation.comfort = 40 + y
                 start_relation.respect = 30 + y
@@ -511,7 +511,7 @@ def create_new_cat_block(
                 par.relationships[n_c.ID] = start_relation
 
                 y = randrange(0, 20)
-                start_relation = Relationship(n_c, par, False, True)
+                start_relation = Relationship(n_c, par, family=True)
                 start_relation.like += 40 + y
                 start_relation.comfort = 70 + y
                 start_relation.respect = 30 + y

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -1744,7 +1744,7 @@ class Pregnancy_Events:
                             "parent_to_kit"
                         ]
                         y = random.randrange(0, 15)
-                        start_relation = Relationship(the_cat, kit, False, True)
+                        start_relation = Relationship(the_cat, kit, family=True)
                         start_relation.like = parent_to_kit[RelType.LIKE] + y
                         start_relation.comfort = parent_to_kit[RelType.COMFORT] + y
                         start_relation.respect = parent_to_kit[RelType.RESPECT] + y
@@ -1755,7 +1755,7 @@ class Pregnancy_Events:
                             "kit_to_parent"
                         ]
                         y = random.randrange(0, 15)
-                        start_relation = Relationship(kit, the_cat, False, True)
+                        start_relation = Relationship(kit, the_cat, family=True)
                         start_relation.like += kit_to_parent[RelType.LIKE] + y
                         start_relation.comfort = kit_to_parent[RelType.COMFORT] + y
                         start_relation.respect = kit_to_parent[RelType.RESPECT] + y
@@ -1779,7 +1779,7 @@ class Pregnancy_Events:
                 y = random.randrange(0, 10)
                 if second_kitten.ID == kitten.ID:
                     continue
-                start_relation = Relationship(kitten, second_kitten, False, True)
+                start_relation = Relationship(kitten, second_kitten, family=True)
                 start_relation.like += (
                     constants.CONFIG["new_cat"]["sib_buff"]["cat1_to_cat2"]["like"] + y
                 )


### PR DESCRIPTION
### Motivation
- The `Relationship` constructor usage was made explicit to use the `family` keyword instead of positional boolean flags to avoid incorrect ordering and improve clarity when creating kin relationships.

### Description
- Replaced positional `Relationship(..., False, True)` calls with `Relationship(..., family=True)` in `scripts/events_module/consequences.py` and `scripts/events_module/relationship/pregnancy_events.py`.
- Updated littermate, biological parent, and adoptive parent relationship initializations to use the named `family` argument.
- No other logic or relationship attribute assignments were changed.

### Testing
- Ran the repository test suite with `pytest -q` and all tests passed.
- Ran the project's linter (`flake8`) and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4567accae08333b7f3eab49db1ef17)