### PR TITLE
Fix leader den searches for lost cats

### DIFF
--- a/scripts/events_module/event_filters.py
+++ b/scripts/events_module/event_filters.py
@@ -491,19 +491,33 @@ def _check_cat_status(cat, statuses: list) -> bool:
     if not statuses or "any" in statuses:
         return True
 
+    current_standing_matches = (
+        ("lost" in statuses and cat.status.is_lost(CatGroup.PLAYER_CLAN_ID))
+        or ("exiled" in statuses and cat.status.is_exiled(CatGroup.PLAYER_CLAN_ID))
+        or ("left" in statuses and cat.status.left_group(CatGroup.PLAYER_CLAN_ID))
+    )
+
     if (cat.status.rank in statuses) or (
         "clancat" in statuses and cat.status.is_clancat
-    ):
+    ) or current_standing_matches:
         return True
 
     is_exclusionary = _check_for_exclusionary_value(statuses)
 
     if is_exclusionary:
         statuses = [x.replace("-", "") for x in statuses]
+        current_standing_matches = (
+            ("lost" in statuses and cat.status.is_lost(CatGroup.PLAYER_CLAN_ID))
+            or (
+                "exiled" in statuses
+                and cat.status.is_exiled(CatGroup.PLAYER_CLAN_ID)
+            )
+            or ("left" in statuses and cat.status.left_group(CatGroup.PLAYER_CLAN_ID))
+        )
 
     if (cat.status.rank in statuses) or (
         "clancat" in statuses and cat.status.is_clancat
-    ):
+    ) or current_standing_matches:
         return False
 
     return is_exclusionary


### PR DESCRIPTION
### Motivation
- Leader den outsider/search events that target cats with `status: ["lost"]` (and similar legacy standing names) were not matching because the status filter only checked rank strings and `clancat`, causing empty event lists and an `IndexError` from `random.choice()`.

### Description
- Updated `scripts/events_module/event_filters.py` `_check_cat_status` to treat legacy standing names `lost`, `exiled`, and `left` as checks against the cat's player-clan standing using `cat.status.is_lost`, `cat.status.is_exiled`, and `cat.status.left_group` respectively. 
- Recomputed the standing-match check when handling exclusionary (`-tag`) filters so negatives like `-lost` continue to work correctly.
- Change ensures leader-den events that filter by these statuses can be selected instead of producing an empty list. (File modified: `scripts/events_module/event_filters.py`.)

### Testing
- Ran `python -m compileall -q scripts/events_module/event_filters.py` to ensure the module compiles, which succeeded. 
- Executed a smoke test script under project environment (`uv run python`) that asserts `_check_cat_status` returns `True` for `['lost']`, `False` for `['-lost']`, and `False` for `['exiled']`, which passed. 
- Ran `git diff --check` and basic repository checks after committing the change, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45b6965eb483338fa8f6ab55c954b9)