### PR TITLE
Fix name rule loading for faded cats

### DIFF
--- a/scripts/cat/names.py
+++ b/scripts/cat/names.py
@@ -65,6 +65,11 @@ class Name:
                 name_fixpref = False
 
         if self.suffix and not load_existing_name:
+            # Existing names can be constructed before any generated-name path has
+            # loaded the localized name data, such as while loading faded cats for
+            # inheritance. Ensure validation has the name rule categories it needs.
+            self.load_localized_names()
+
             # Prevent triple letter names from joining prefix and suffix from occurring (ex. Beeeye)
             possible_three_letter = (
                 self.prefix[-2:] + self.suffix[0],

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -11,6 +11,7 @@ os.environ["SDL_AUDIODRIVER"] = "dummy"
 from scripts.game_structure import game, constants
 
 from scripts.cat.cats import Cat
+from scripts.cat.names import Name
 from scripts.cat_relations.inheritance2 import inheritance_db
 from scripts.cat.enums import CatAge, CatRank, CatGroup, CatSocial
 from scripts.cat_relations.relationship import Relationship
@@ -46,6 +47,30 @@ class TestCreationAge(unittest.TestCase):
     def test_elder(self):
         test_cat = Cat(moons=120, disable_random=True)
         self.assertEqual(test_cat.age, CatAge.SENIOR)
+
+
+class TestNameLoading(unittest.TestCase):
+    def test_existing_name_loads_name_rules_before_validation(self):
+        # Faded cats are created with existing prefixes and suffixes before any
+        # generated-name path has necessarily loaded the localized name data.
+        original_names_dict = Name.names_dict
+        original_save_dir = Name.current_save_dir
+        original_lang = Name.currently_loaded_lang
+
+        try:
+            Name.names_dict = {}
+            Name.current_save_dir = None
+            Name.currently_loaded_lang = None
+
+            name = Name(prefix="Rain", suffix="fall")
+
+            self.assertEqual(name.prefix, "Rain")
+            self.assertEqual(name.suffix, "fall")
+            self.assertIn("animal_prefixes", name.names_dict)
+        finally:
+            Name.names_dict = original_names_dict
+            Name.current_save_dir = original_save_dir
+            Name.currently_loaded_lang = original_lang
 
 
 class TestRelativesFunction(unittest.TestCase):


### PR DESCRIPTION
### Motivation
- Prevent a `KeyError: 'animal_prefixes'` when loading faded/inherited cats whose stored prefix/suffix are validated before localized name rules have been loaded.

### Description
- Ensure localized name rule data is loaded by calling `self.load_localized_names()` before validating existing prefix/suffix pairs in `Name.__init__` in `scripts/cat/names.py`.
- Add a regression test `TestNameLoading.test_existing_name_loads_name_rules_before_validation` in `tests/test_cat.py` that clears the `Name` cache, constructs an existing name, and verifies the name pieces are preserved and the `animal_prefixes` category is present.

### Testing
- Ran `python -m py_compile scripts/cat/names.py tests/test_cat.py` which succeeded to ensure syntax is valid.
- Attempted `python -m pytest tests/test_cat.py::TestNameLoading -q` but it failed to collect due to a missing environment dependency (`ModuleNotFoundError: No module named 'i18n'`) in this run-time environment, so the unit test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bfa33ac508333a9b8c65078f474f2)