### PR TITLE
Avoid KeyError for missing name categories; add fallback and safe accessors

### DIFF
--- a/scripts/cat/names.py
+++ b/scripts/cat/names.py
@@ -5,6 +5,7 @@ Module that handles the name generation for all cats.
 import contextlib
 import os
 import random
+from copy import deepcopy
 
 import i18n
 import ujson
@@ -23,6 +24,27 @@ class Name:
     current_save_dir = None
     currently_loaded_lang = None
     names_dict = {}
+    _fallback_names_dict = None
+    _list_categories = (
+        "animal_prefixes",
+        "animal_suffixes",
+        "clan_prefixes",
+        "human_names",
+        "inappropriate_names",
+        "loner_names",
+        "normal_prefixes",
+        "normal_suffixes",
+        "silly_names",
+    )
+    _dict_categories = (
+        "biome_prefixes",
+        "biome_suffixes",
+        "colour_prefixes",
+        "eye_prefixes",
+        "pelt_suffixes",
+        "special_suffixes",
+        "tortie_pelt_suffixes",
+    )
 
     def __init__(
         self,
@@ -129,6 +151,54 @@ class Name:
                     double_animal = False
                 i += 1
 
+    @classmethod
+    def _load_fallback_names(cls):
+        """Load English name data used to fill missing localization keys."""
+        if cls._fallback_names_dict is None:
+            with open("resources/lang/en/names.json", encoding="utf-8") as read_file:
+                cls._fallback_names_dict = ujson.loads(read_file.read())
+        return deepcopy(cls._fallback_names_dict)
+
+    @classmethod
+    def _normalize_names_dict(cls, names_dict):
+        """Ensure every expected name category exists to avoid KeyErrors."""
+        fallback_names = cls._load_fallback_names()
+        normalized_names = deepcopy(names_dict) if names_dict else {}
+
+        for category in cls._list_categories:
+            fallback_value = fallback_names.get(category, [])
+            value = normalized_names.get(category)
+            if not isinstance(value, list) or not value:
+                normalized_names[category] = deepcopy(fallback_value)
+
+        for category in cls._dict_categories:
+            fallback_value = fallback_names.get(category, {})
+            value = normalized_names.get(category)
+            if not isinstance(value, dict):
+                normalized_names[category] = deepcopy(fallback_value)
+            else:
+                merged_value = deepcopy(fallback_value)
+                merged_value.update(value)
+                normalized_names[category] = merged_value
+
+        return normalized_names
+
+    @classmethod
+    def get_category(cls, category):
+        """Return a safe name category, loading names if needed."""
+        names.load_localized_names()
+        return cls.names_dict[category]
+
+    @classmethod
+    def normal_name_combinations(cls):
+        """Return the number of normal prefix/suffix combinations available."""
+        names.load_localized_names()
+        return max(
+            1,
+            len(cls.names_dict["normal_prefixes"])
+            * len(cls.names_dict["normal_suffixes"]),
+        )
+
     def load_localized_names(self):
         """
         Loads the correct names for the given language. Includes override for always using English names, in case localization wants to be ignored
@@ -146,6 +216,8 @@ class Name:
         if (
             self.current_save_dir == get_save_dir()
             and self.currently_loaded_lang == lang
+            and self.names_dict
+            and type(self).names_dict
         ):
             # nothing to do here, all good
             return
@@ -155,6 +227,8 @@ class Name:
                 names_dict = ujson.loads(read_file.read())
         else:
             names_dict = load_lang_resource("names.json")
+
+        names_dict = self._normalize_names_dict(names_dict)
 
         save_dir = get_save_dir()
 
@@ -194,7 +268,7 @@ class Name:
 
         if os.path.exists(save_dir + "/specialsuffixes.txt"):
             with open(
-                str(save_dir + "/specialsuffixes.txt", "r"), encoding="utf-8"
+                str(save_dir + "/specialsuffixes.txt"), "r", encoding="utf-8"
             ) as read_file:
                 name_list = read_file.read()
                 if_names = len(name_list)
@@ -203,14 +277,15 @@ class Name:
                 for new_name in new_names:
                     if new_name != "":
                         if new_name.startswith("-"):
-                            del names_dict["special_suffixes"][new_name[1:]]
+                            names_dict["special_suffixes"].pop(new_name[1:], None)
                         elif ":" in new_name:
                             _tmp = new_name.split(":")
                             names_dict["special_suffixes"][_tmp[0]] = _tmp[1]
 
         self.names_dict = names_dict
-        self.current_save_dir = save_dir
-        self.currently_loaded_lang = lang
+        type(self).names_dict = names_dict
+        type(self).current_save_dir = save_dir
+        type(self).currently_loaded_lang = lang
 
     def __str__(self):
         return self.__repr__()

--- a/scripts/clan_package/clan_names.py
+++ b/scripts/clan_package/clan_names.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from scripts.cat.names import names
+from scripts.cat.names import Name
 from scripts.game_structure import constants
 from scripts.game_structure.localization import get_lang_config
 
@@ -10,10 +10,10 @@ def get_possible_clan_names() -> List[str]:
     Returns a list of all possible names for a Clan, handling logic on what names may appear
     :return: A list of possible Clan prefixes
     """
-    clan_names = names.names_dict["clan_prefixes"]
+    clan_names = list(Name.get_category("clan_prefixes"))
 
     if constants.CONFIG["cat_name_controls"][
         "always_use_english"
     ] or get_lang_config().get("names", {}).get("clans_can_have_cat_prefixes", True):
-        clan_names += names.names_dict["normal_prefixes"]
+        clan_names += Name.get_category("normal_prefixes")
     return clan_names

--- a/scripts/events_module/consequences.py
+++ b/scripts/events_module/consequences.py
@@ -14,7 +14,7 @@ from scripts.cat.enums import (
     CatStanding,
     CatThought,
 )
-from scripts.cat.names import Name, names
+from scripts.cat.names import Name
 from scripts.cat_relations.enums import RelType
 from scripts.cat_relations.inheritance2 import inheritance_db
 from scripts.clan_package.settings import get_clan_setting
@@ -714,7 +714,7 @@ def create_new_cat(
                     weights = constants.CONFIG["cat_name_controls"]["rogue"]
 
                 selected_category = choices(name_categories, weights, k=1)[0]
-                name = choice(names.names_dict[selected_category])
+                name = choice(Name.get_category(selected_category))
                 new_cat.change_name(new_prefix=name, new_suffix="")
             else:
                 # means that this young cat joins the clan and gets indoctrinated, muahaha
@@ -738,11 +738,7 @@ def create_new_cat(
                     if cat.ID not in excluded_ids and cat.status.alive_in_player_clan
                 }
 
-                max_attempts = max(
-                    1,
-                    len(Name.names_dict["normal_prefixes"])
-                    * len(Name.names_dict["normal_suffixes"]),
-                )
+                max_attempts = Name.normal_name_combinations()
                 for _ in range(max_attempts):
                     if new_cat.name.prefix in used_prefixes:
                         new_cat.name = Name(
@@ -788,7 +784,7 @@ def create_new_cat(
                 weights = constants.CONFIG["cat_name_controls"]["rogue"]
 
             selected_category = choices(name_categories, weights, k=1)[0]
-            name = choice(names.names_dict[selected_category])
+            name = choice(Name.get_category(selected_category))
 
             # now, if this cat should take a new clan name, we give them such
             if new_name:

--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -15,7 +15,7 @@ from scripts.cat.enums import (
     CatCompatibility,
     CatThought,
 )
-from scripts.cat.names import names, Name
+from scripts.cat.names import Name
 from scripts.cat.status import StatusDict
 from scripts.cat_relations.relationship import Relationship, RelType
 from scripts.cat_relations.inheritance2 import inheritance_db
@@ -204,11 +204,7 @@ class Pregnancy_Events:
             if cat.ID not in excluded_ids and cat.status.alive_in_player_clan
         )
 
-        max_attempts = max(
-            1,
-            len(Name.names_dict["normal_prefixes"])
-            * len(Name.names_dict["normal_suffixes"]),
-        )
+        max_attempts = Name.normal_name_combinations()
         for _ in range(max_attempts):
             if kit.name.prefix in used_prefixes:
                 kit.name = Name(
@@ -277,11 +273,7 @@ class Pregnancy_Events:
             if cat.ID not in excluded_ids and cat.status.alive_in_player_clan
         )
 
-        max_attempts = max(
-            1,
-            len(Name.names_dict["normal_prefixes"])
-            * len(Name.names_dict["normal_suffixes"]),
-        )
+        max_attempts = Name.normal_name_combinations()
         for _ in range(max_attempts):
             if kit.name.prefix in used_prefixes:
                 kit.name = Name(
@@ -888,7 +880,7 @@ class Pregnancy_Events:
                 kit.backstory = "outsider1"
 
                 if cat.status.is_exiled(CatGroup.PLAYER_CLAN_ID):
-                    name = choice(names.names_dict["normal_prefixes"])
+                    name = choice(Name.get_category("normal_prefixes"))
                     kit.name = Name(prefix=name, suffix="", cat=kit)
                     extra_naming_text = i18n.t(
                         "conditions.pregnancy.reject_clan_tradition",
@@ -901,7 +893,7 @@ class Pregnancy_Events:
                 if cat.status.is_lost(CatGroup.PLAYER_CLAN_ID):
                     kit.backstory = "outsider3"
                     if not keep_clan_tradition:
-                        name = choice(names.names_dict["normal_prefixes"])
+                        name = choice(Name.get_category("normal_prefixes"))
                         kit.name = Name(prefix=name, suffix="", cat=kit)
                         extra_naming_text = i18n.t(
                             "conditions.pregnancy.reject_clan_tradition",

--- a/scripts/screens/make_clan_screens/MakeClanScreenBase.py
+++ b/scripts/screens/make_clan_screens/MakeClanScreenBase.py
@@ -10,7 +10,7 @@ import pygame_gui
 from scripts.cat import save_load
 from scripts.cat.cats import Cat, create_cat
 from scripts.cat.enums import CatAge, CatRank, CatSocial, CatGroup
-from scripts.cat.names import names
+from scripts.cat.names import Name
 from scripts.cat.status import Status
 from scripts.clan import Clan
 from scripts.clan_package.clan_names import get_possible_clan_names
@@ -291,7 +291,7 @@ class MakeClanScreenBase(Screens):
                     weights = constants.CONFIG["cat_name_controls"]["rogue"]
 
                 selected_category = choices(name_categories, weights, k=1)[0]
-                name = choice(names.names_dict[selected_category])
+                name = choice(Name.get_category(selected_category))
                 c.change_name(new_prefix=name, new_suffix="")
 
                 # add back to all_cats, cus they get removed during `create_clan()`


### PR DESCRIPTION
### Motivation
- A missing or incomplete localized `names.json` could raise `KeyError` (e.g. `'normal_prefixes'`) during name generation and timeskipping. 
- Prevent similar crashes anywhere code indexed `Name.names_dict` directly by providing safe defaults and accessors.

### Description
- Add English fallback loading and a normalizing helper `Name._normalize_names_dict` to ensure expected list and dict categories always exist. 
- Add safe helpers `Name.get_category` and `Name.normal_name_combinations`, and keep `Name.names_dict` synchronized when localized names are loaded. 
- Replace direct `names.names_dict[...]` lookups with `Name.get_category(...)` and use `Name.normal_name_combinations()` in `scripts/events_module/relationship/pregnancy_events.py`, `scripts/events_module/consequences.py`, `scripts/screens/make_clan_screens/MakeClanScreenBase.py`, and `scripts/clan_package/clan_names.py`. 
- Make removal of special suffix overrides resilient by using `.pop(..., None)` and fix a minor `open()` argument ordering issue.

### Testing
- Ran a syntax/compile check with `python -m py_compile scripts/cat/names.py scripts/events_module/consequences.py scripts/events_module/relationship/pregnancy_events.py scripts/clan_package/clan_names.py scripts/screens/make_clan_screens/MakeClanScreenBase.py`, which completed without errors. 
- Executed a small runtime check in the project virtualenv (`.venv/bin/python`) that exercises `Name._normalize_names_dict({})` and `Name.normal_name_combinations()` and confirmed it returned a truthy result (test printed `True`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bfee2592483339606a24ff55bba99)