### PR TITLE
Create reciprocal Relationship objects for kits and ensure opposite_relationship exists in Relationship Log

### DIFF
--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -1083,23 +1083,21 @@ class Pregnancy_Events:
             and coparenting_outcome
         ):
             if coparenting_outcome == "negative":
-                dislike_value = constants.CONFIG["relationship"]["value_intervals"][
-                    "low_neg"
-                ]
                 absent_parent_to_kit_reaction = constants.CONFIG["new_cat"]["parent_buff"][
                     "absent_parent_to_kit"
                 ]
                 for kit in kits:
-                    absent_parent_to_kit = other_cat.relationships.get(kit.ID)
-                    if not absent_parent_to_kit:
-                        absent_parent_to_kit = Relationship(other_cat, kit, family=True)
-                        other_cat.relationships[kit.ID] = absent_parent_to_kit
+                    absent_parent_to_kit = Relationship(other_cat, kit, family=True)
+                    other_cat.relationships[kit.ID] = absent_parent_to_kit
                     absent_parent_to_kit.like += absent_parent_to_kit_reaction["like"]
                     absent_parent_to_kit.respect += absent_parent_to_kit_reaction["respect"]
                     absent_parent_to_kit.comfort += absent_parent_to_kit_reaction["comfort"]
                     absent_parent_to_kit.trust += absent_parent_to_kit_reaction["trust"]
-                    kit.relationships.pop(other_cat.ID, None)
-            
+                    kit_to_absent_parent = Relationship(kit, other_cat, family=True)
+                    kit.relationships[other_cat.ID] = kit_to_absent_parent
+                    absent_parent_to_kit.opposite_relationship = kit_to_absent_parent
+                    kit_to_absent_parent.opposite_relationship = absent_parent_to_kit
+
             for first_cat, second_cat in ((cat, other_cat), (other_cat, cat)):
                 rel = first_cat.relationships.get(second_cat.ID)
                 if not rel:

--- a/scripts/ui/windows/relationship_log.py
+++ b/scripts/ui/windows/relationship_log.py
@@ -30,9 +30,14 @@ class RelationshipLogWindow(GameWindow):
         self.cat_to: Cat = relationship.cat_to
 
         self.relationship: Relationship = relationship
-        self.opposite_relationship: Relationship = self.cat_to.relationships[
+        self.opposite_relationship: Relationship = self.cat_to.relationships.get(
             self.cat_from.ID
-        ]
+        )
+        if self.opposite_relationship is None:
+            self.opposite_relationship = Relationship(self.cat_to, self.cat_from)
+            self.cat_to.relationships[self.cat_from.ID] = self.opposite_relationship
+        self.relationship.opposite_relationship = self.opposite_relationship
+        self.opposite_relationship.opposite_relationship = self.relationship
 
         self.elements: dict = {}
         self.selected_cat_elements: dict = {}
@@ -84,7 +89,7 @@ class RelationshipLogWindow(GameWindow):
             text_kwargs={"cat": short_name},
             manager=MANAGER,
         )
-        if self.relationship.log:
+        if self.opposite_relationship.log:
             logs = self.opposite_relationship.log.copy()
             logs.reverse()
             log_string = "<br><br>".join(logs)


### PR DESCRIPTION
### Motivation

- Fix missing reciprocal relationships and opposite links when unmated co-parenting produces kits so relationship data is consistent between cats and kits.
- Avoid errors in the relationship log UI when an opposite relationship is missing by ensuring the opposite exists before rendering.

### Description

- In `scripts/events_module/relationship/pregnancy_events.py` always create a `Relationship` from the absent parent to each `kit`, add it to `other_cat.relationships`, create the reciprocal `Relationship` from each `kit` to the absent parent, and link both via `opposite_relationship`; also remove an unused `dislike_value` variable.
- In `scripts/ui/windows/relationship_log.py` guard access to the opposite relationship using `.get`, create and register a `Relationship` if missing, and set `opposite_relationship` on both sides so the UI has a consistent reciprocal relationship to read from.
- Update the relationship log display to use the opposite relationship's `log` for the second cat so the two panes show each cat's perspective correctly.

### Testing

- Ran the project's unit test suite with `pytest` which includes relationship and pregnancy event tests, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a600ca54a30832cbdb52a648b52e49c)