### PR TITLE
Use `game.clan` for pregnancy data and remove redundant `clan` args from announcements

### DIFF
--- a/scripts/events_module/relationship/pregnancy_events.py
+++ b/scripts/events_module/relationship/pregnancy_events.py
@@ -174,7 +174,7 @@ class Pregnancy_Events:
     ):
         """Store whether an affair was explicitly announced in pregnancy data."""
         target_cat = cat or pregnant_cat
-        if not target_cat or not clan:
+        if not target_cat or not game.clan:
             return
         pregnancy = game.clan.pregnancy_data.get(target_cat.ID)
         if pregnancy is None:
@@ -455,14 +455,14 @@ class Pregnancy_Events:
             # the pregnancy will be announced as normal
             if other_cat and other_cat.ID in cat.mate:
                 text, involved_cats = Pregnancy_Events.create_pregnancy_announcement(
-                    cat, "announcement", clan, random_cat=other_cat
+                    cat, "announcement", random_cat=other_cat
                 )
             # if the pregnant cat is single and had a fling with a random cat, let them
             # announce their surprise pregnancy and leave the Clan and player pointing
             # fingers on who the second parent may be
             elif allow_coparenting and not mate:
                 text, involved_cats = Pregnancy_Events.create_pregnancy_announcement(
-                    cat, "announcement_surprise", clan
+                    cat, "announcement_surprise"
                 )
 
             # and lastly, if the pregnant cat got knocked up by another cat who ISN'T their mate,
@@ -478,16 +478,15 @@ class Pregnancy_Events:
                 Pregnancy_Events.set_affair_visibility_on_pregnancy(
                     cat,
                     announcement_key == "announcement_affair",
-                    clan=clan,
                 )
                 random_cat = mate[0]
                 text, involved_cats = Pregnancy_Events.create_pregnancy_announcement(
-                    cat, announcement_key, clan, random_cat=random_cat
+                    cat, announcement_key, random_cat=random_cat
                 )
             # if all else fails, just a regular announcement happens
             else:
                 text, involved_cats = Pregnancy_Events.create_pregnancy_announcement(
-                    cat, "announcement", clan, random_cat=other_cat
+                    cat, "announcement", random_cat=other_cat
                 )
             game.cur_events_list.append(
                 Single_Event(text, "birth_death", involved_cats)
@@ -536,14 +535,14 @@ class Pregnancy_Events:
             # the pregnancy will be announced as normal
             if second_parent and second_parent.ID in pregnant_cat.mate:
                 text, involved_cats = Pregnancy_Events.create_pregnancy_announcement(
-                    pregnant_cat, "announcement", clan, random_cat=second_parent
+                    pregnant_cat, "announcement", random_cat=second_parent
                 )
             # if the pregnant cat is single and had a fling with a random cat, let them
             # announce their surprise pregnancy and leave the Clan and player pointing
             # fingers on who the second parent may be
             elif allow_coparenting and not mate:
                 text, involved_cats = Pregnancy_Events.create_pregnancy_announcement(
-                    pregnant_cat, "announcement_surprise", clan
+                    pregnant_cat, "announcement_surprise"
                 )
             # if the pregnant cat is in a same-sex relationship and they get knocked-up
             # by another cat, let there be some drama for that!
@@ -557,7 +556,6 @@ class Pregnancy_Events:
                 text, involved_cats = Pregnancy_Events.create_pregnancy_announcement(
                     pregnant_cat,
                     "announcement_affair_samesex",
-                    clan,
                     random_cat=random_cat,
                 )
             # and lastly, if the pregnant cat got knocked up by another cat who ISN'T their mate,
@@ -573,16 +571,15 @@ class Pregnancy_Events:
                 Pregnancy_Events.set_affair_visibility_on_pregnancy(
                     pregnant_cat,
                     announcement_key == "announcement_affair",
-                    clan=clan,
                 )
                 random_cat = amab_mate[0] if amab_mate else None
                 text, involved_cats = Pregnancy_Events.create_pregnancy_announcement(
-                    pregnant_cat, announcement_key, clan, random_cat=random_cat
+                    pregnant_cat, announcement_key, random_cat=random_cat
                 )
             # if all else fails, just a regular announcement happens
             else:
                 text, involved_cats = Pregnancy_Events.create_pregnancy_announcement(
-                    pregnant_cat, "announcement", clan, random_cat=second_parent
+                    pregnant_cat, "announcement", random_cat=second_parent
                 )
             game.cur_events_list.append(
                 Single_Event(text, "birth_death", involved_cats)


### PR DESCRIPTION
### Motivation

- Fix runtime risk from an undefined `clan` variable and simplify pregnancy-related call sites by relying on the global `game.clan` for pregnancy data and announcement behavior.

### Description

- Remove passing of an explicit `clan` argument to pregnancy announcement functions and to `set_affair_visibility_on_pregnancy`, and update call sites accordingly.
- Update `set_affair_visibility_on_pregnancy` to check `game.clan` instead of an undefined `clan` variable when accessing pregnancy data.
- Centralize pregnancy dictionary access to `game.clan.pregnancy_data` so pregnancy visibility and announcement logic use the same global clan state.
- Minor cleanup to mate collection logic during pregnancy handling to keep related variables consistent.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62c834b074832ca76b06adde351ceb)